### PR TITLE
refactor: expose design tokens via CSS variables

### DIFF
--- a/src/client/game/config/DesignSystem.ts
+++ b/src/client/game/config/DesignSystem.ts
@@ -1,3 +1,5 @@
+import type * as Phaser from 'phaser';
+
 /**
  * Modern Design System for Hexomind - 2025 UI Standards
  *
@@ -62,6 +64,7 @@ export class DesignSystem {
       warning: ['#f5af19', '#f12711'],      // Orange-red gradient
       danger: ['#ff6b6b', '#ee5a24'],       // Red gradient
       info: ['#667eea', '#63a4ff'],         // Blue gradient
+      successSoft: ['#00c550', '#00e560', '#00ff70'], // Light mode success gradient
       // Special gradient for HEXOMIND title
       title: ['#667eea', '#764ba2', '#f093fb'], // Purple to pink gradient
       titleAlt: ['#00f5ff', '#8b00ff', '#ff006e'], // Cyan to purple to pink
@@ -91,6 +94,7 @@ export class DesignSystem {
       hover: 'rgba(255, 255, 255, 0.1)',
       active: 'rgba(255, 255, 255, 0.15)',
       disabled: 'rgba(255, 255, 255, 0.3)',
+      textInverseMuted: 'rgba(10, 10, 15, 0.7)',
     },
 
     // Glass morphism effects
@@ -99,6 +103,32 @@ export class DesignSystem {
       backgroundHover: 'rgba(255, 255, 255, 0.08)',
       border: 'rgba(255, 255, 255, 0.1)',
       borderHover: 'rgba(255, 255, 255, 0.2)',
+      borderAccent: 'rgba(102, 126, 234, 0.15)',
+      borderAccentStrong: 'rgba(102, 126, 234, 0.3)',
+    },
+
+    // Accent palette for specific UI components
+    accents: {
+      teal: '#4ecdc4',
+      coral: '#ff6b6b',
+      coralMuted: '#d44860',
+      midnight: '#0f0f1e',
+      indigo: '#667eea',
+      indigoSurface: '#2a2a3e',
+      indigoSurfaceHover: '#3a3a4e',
+      indigoSurfaceBorder: '#444455',
+      mint: '#10b981',
+      crimson: '#dc2626',
+      amber: '#f59e0b',
+      gold: '#ffd700',
+      silver: '#c0c0c0',
+      bronze: '#cd7f32',
+      gray: '#888888',
+      grayMuted: '#666666',
+      grayLight: '#aaaaaa',
+      grayLighter: '#cccccc',
+      blueSoft: '#5290dd',
+      successSoft: '#00c550',
     },
   } as const;
 
@@ -182,11 +212,207 @@ export class DesignSystem {
 
   private constructor() {}
 
+  private static cssVariablesApplied = false;
+
   static getInstance(): DesignSystem {
     if (!DesignSystem.instance) {
       DesignSystem.instance = new DesignSystem();
     }
     return DesignSystem.instance;
+  }
+
+  /**
+   * Convert camelCase or snake_case to kebab-case for CSS variables
+   */
+  private static toKebabCase(value: string): string {
+    return value
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/_/g, '-')
+      .toLowerCase();
+  }
+
+  /**
+   * Apply nested object values as CSS variables with a prefix
+   */
+  private static applyNestedVariables(
+    style: CSSStyleDeclaration,
+    prefix: string,
+    obj: Record<string, unknown>
+  ): void {
+    Object.entries(obj).forEach(([key, value]) => {
+      const varName = `${prefix}-${DesignSystem.toKebabCase(key)}`;
+
+      if (Array.isArray(value)) {
+        const list = value as string[];
+        style.setProperty(varName, list.join(', '));
+        list.forEach((entry, index) => {
+          style.setProperty(`${varName}-${index}`, entry);
+        });
+        return;
+      }
+
+      if (typeof value === 'object' && value !== null) {
+        DesignSystem.applyNestedVariables(style, varName, value as Record<string, unknown>);
+        return;
+      }
+
+      style.setProperty(varName, `${value}`);
+    });
+  }
+
+  /**
+   * Ensure all design tokens are exposed as CSS variables on :root
+   */
+  static applyCssVariables(): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const style = document.documentElement.style;
+
+    Object.entries(DesignSystem.SPACING).forEach(([key, value]) => {
+      style.setProperty(`--spacing-${DesignSystem.toKebabCase(key)}`, `${value}px`);
+    });
+
+    DesignSystem.applyNestedVariables(style, '--typography', DesignSystem.TYPOGRAPHY as unknown as Record<string, unknown>);
+    DesignSystem.applyNestedVariables(style, '--color', DesignSystem.COLORS as unknown as Record<string, unknown>);
+
+    DesignSystem.cssVariablesApplied = true;
+  }
+
+  private static ensureCssVariables(): void {
+    if (!DesignSystem.cssVariablesApplied) {
+      DesignSystem.applyCssVariables();
+    }
+  }
+
+  /**
+   * Get a CSS variable value with optional fallback
+   */
+  static getCssVariableValue(varName: string, fallback?: string): string {
+    if (typeof document === 'undefined') {
+      return fallback ?? '';
+    }
+
+    DesignSystem.ensureCssVariables();
+
+    const value = getComputedStyle(document.documentElement).getPropertyValue(varName);
+    if (value && value.trim().length > 0) {
+      return value.trim();
+    }
+
+    return fallback ?? '';
+  }
+
+  /**
+   * Get numeric spacing value from CSS variables
+   */
+  static getSpacingValue(key: keyof typeof DesignSystem.SPACING): number {
+    const fallback = DesignSystem.SPACING[key];
+    const raw = DesignSystem.getCssVariableValue(`--spacing-${DesignSystem.toKebabCase(key)}`, `${fallback}px`);
+    const parsed = parseFloat(raw);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+
+  static getFontFamily(key: keyof typeof DesignSystem.TYPOGRAPHY.fontFamily): string {
+    const fallback = DesignSystem.TYPOGRAPHY.fontFamily[key];
+    return DesignSystem.getCssVariableValue(`--typography-font-family-${DesignSystem.toKebabCase(key)}`, fallback);
+  }
+
+  static getFontSize(key: keyof typeof DesignSystem.TYPOGRAPHY.fontSize): string {
+    const fallback = DesignSystem.TYPOGRAPHY.fontSize[key];
+    return DesignSystem.getCssVariableValue(`--typography-font-size-${DesignSystem.toKebabCase(key)}`, fallback);
+  }
+
+  static getFontWeight(key: keyof typeof DesignSystem.TYPOGRAPHY.fontWeight): string {
+    const fallback = DesignSystem.TYPOGRAPHY.fontWeight[key];
+    return DesignSystem.getCssVariableValue(`--typography-font-weight-${DesignSystem.toKebabCase(key)}`, fallback);
+  }
+
+  static getLineHeight(key: keyof typeof DesignSystem.TYPOGRAPHY.lineHeight): string {
+    const fallback = DesignSystem.TYPOGRAPHY.lineHeight[key];
+    return DesignSystem.getCssVariableValue(`--typography-line-height-${DesignSystem.toKebabCase(key)}`, fallback);
+  }
+
+  static getColor(
+    category: 'solid' | 'glass' | 'accents',
+    key: string
+  ): string {
+    const collection = DesignSystem.COLORS[category] as Record<string, string> | undefined;
+    const fallback = collection?.[key] ?? '';
+    return DesignSystem.getCssVariableValue(`--color-${DesignSystem.toKebabCase(category)}-${DesignSystem.toKebabCase(key)}`, fallback);
+  }
+
+  static getColorNumber(category: 'solid' | 'glass' | 'accents', key: string, fallback?: string): number {
+    const color = DesignSystem.getColor(category, key) || fallback || '#000000';
+    return DesignSystem.colorStringToNumber(color, fallback);
+  }
+
+  static getGradient(name: keyof typeof DesignSystem.COLORS.gradients): string[] {
+    const fallback = DesignSystem.COLORS.gradients[name];
+    const raw = DesignSystem.getCssVariableValue(`--color-gradients-${DesignSystem.toKebabCase(name)}`, fallback.join(', '));
+    const values = raw
+      .split(',')
+      .map(token => token.trim())
+      .filter(Boolean);
+    return values.length > 0 ? values : [...fallback];
+  }
+
+  static getGradientColor(name: keyof typeof DesignSystem.COLORS.gradients, index: number): string {
+    const gradient = DesignSystem.getGradient(name);
+    if (gradient.length === 0) {
+      return '#000000';
+    }
+    return gradient[Math.min(index, gradient.length - 1)];
+  }
+
+  static resolveColor(color: string, fallback?: string): string {
+    const trimmed = color?.trim();
+    if (!trimmed || trimmed.length === 0) {
+      return fallback ?? '';
+    }
+
+    if (trimmed.startsWith('var(')) {
+      const varName = trimmed.slice(4, -1).trim();
+      return DesignSystem.getCssVariableValue(varName, fallback);
+    }
+
+    return trimmed;
+  }
+
+  static colorStringToNumber(color: string, fallback?: string): number {
+    const resolved = DesignSystem.resolveColor(color, fallback ?? '#000000') || fallback || '#000000';
+    const trimmed = resolved.trim();
+
+    if (trimmed.startsWith('#')) {
+      const hex = trimmed.slice(1);
+      const normalized = hex.length === 3
+        ? hex.split('').map(ch => ch + ch).join('')
+        : hex;
+      const parsed = parseInt(normalized, 16);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+
+    const rgbMatch = trimmed.match(/^rgba?\(([^)]+)\)$/i);
+    if (rgbMatch) {
+      const parts = rgbMatch[1]
+        .split(',')
+        .map(part => parseFloat(part.trim()))
+        .slice(0, 3)
+        .map(component => Math.max(0, Math.min(255, Math.round(component))));
+      if (parts.length === 3 && parts.every(value => !Number.isNaN(value))) {
+        const [r, g, b] = parts;
+        return (r << 16) + (g << 8) + b;
+      }
+    }
+
+    if (fallback && fallback !== color) {
+      return DesignSystem.colorStringToNumber(fallback);
+    }
+
+    return 0;
   }
 
   /**
@@ -201,22 +427,24 @@ export class DesignSystem {
     }
   ): Phaser.Types.GameObjects.Text.TextStyle {
     const sizeMap = {
-      display: DesignSystem.TYPOGRAPHY.fontSize['3xl'],
-      heading: DesignSystem.TYPOGRAPHY.fontSize['2xl'],
-      body: DesignSystem.TYPOGRAPHY.fontSize.base,
-      caption: DesignSystem.TYPOGRAPHY.fontSize.sm,
-      button: DesignSystem.TYPOGRAPHY.fontSize.lg,
-    };
+      display: DesignSystem.getFontSize('3xl'),
+      heading: DesignSystem.getFontSize('2xl'),
+      body: DesignSystem.getFontSize('base'),
+      caption: DesignSystem.getFontSize('sm'),
+      button: DesignSystem.getFontSize('lg'),
+    } as const;
 
     // Weight is handled through fontStyle in Phaser
 
     return {
       fontFamily: variant === 'display'
-        ? DesignSystem.TYPOGRAPHY.fontFamily.display
-        : DesignSystem.TYPOGRAPHY.fontFamily.body,
+        ? DesignSystem.getFontFamily('display')
+        : DesignSystem.getFontFamily('body'),
       fontSize: sizeMap[variant],
       fontStyle: options?.weight ? 'normal' : 'normal',
-      color: options?.color || DesignSystem.COLORS.solid.textPrimary,
+      color: options?.color
+        ? DesignSystem.resolveColor(options.color, DesignSystem.getColor('solid', 'textPrimary'))
+        : DesignSystem.getColor('solid', 'textPrimary'),
       align: options?.align || 'center',
     };
   }
@@ -243,14 +471,14 @@ export class DesignSystem {
    * Convert hex color to Phaser number format
    */
   static hexToNumber(hex: string): number {
-    return parseInt(hex.replace('#', ''), 16);
+    return DesignSystem.colorStringToNumber(hex);
   }
 
   /**
    * Get consistent spacing value
    */
   static spacing(multiplier: number = 1): number {
-    return DesignSystem.SPACING.sm * multiplier;
+    return DesignSystem.getSpacingValue('sm') * multiplier;
   }
 
   /**
@@ -280,4 +508,8 @@ export class DesignSystem {
 }
 
 // Export as singleton for easy access
+if (typeof document !== 'undefined') {
+  DesignSystem.applyCssVariables();
+}
+
 export const DS = DesignSystem;

--- a/src/client/game/presentation/theme/NeonThemeProvider.ts
+++ b/src/client/game/presentation/theme/NeonThemeProvider.ts
@@ -3,6 +3,7 @@
  */
 
 import { ColorSystem } from '../../core/colors/ColorSystem';
+import { DesignSystem } from '../../config/DesignSystem';
 
 export class NeonThemeProvider {
   private colorSystem: ColorSystem;
@@ -120,6 +121,7 @@ export class NeonThemeProvider {
    */
   toggleTheme(): void {
     this.colorSystem.toggleMode();
+    DesignSystem.applyCssVariables();
     this.notifyListeners();
   }
 
@@ -130,6 +132,7 @@ export class NeonThemeProvider {
     try {
       const colors = await this.colorSystem.generatePaletteFromColormind('default');
       this.colorSystem.applyCustomPalette(colors);
+      DesignSystem.applyCssVariables();
       this.notifyListeners();
     } catch (error) {
       console.error('Failed to load custom palette:', error);

--- a/src/client/game/presentation/ui/GameOverUI.ts
+++ b/src/client/game/presentation/ui/GameOverUI.ts
@@ -21,6 +21,23 @@ export class GameOverUI extends Phaser.GameObjects.Container {
 
     const { width, height } = scene.cameras.main;
 
+    const spacing = {
+      xl: DS.getSpacingValue('xl'),
+      xxl: DS.getSpacingValue('xxl'),
+      xxxl: DS.getSpacingValue('xxxl'),
+    };
+
+    const colors = {
+      bgPrimary: DS.getColor('solid', 'bgPrimary'),
+      bgElevated: DS.getColor('solid', 'bgElevated'),
+      glassBorder: DS.getColor('glass', 'border'),
+      textPrimary: DS.getColor('solid', 'textPrimary'),
+      danger: DS.getColor('solid', 'danger'),
+      warning: DS.getColor('solid', 'warning'),
+      info: DS.getColor('solid', 'info'),
+      success: DS.getColor('solid', 'success'),
+    };
+
     // Ensure this UI sits above everything else and starts hidden
     this.setDepth(1000);
     this.setVisible(false);
@@ -31,7 +48,7 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2,
       width,
       height,
-      DS.hexToNumber(DS.COLORS.solid.bgPrimary),
+      DS.colorStringToNumber(colors.bgPrimary),
       0.85
     );
     this.background.setInteractive();
@@ -45,22 +62,22 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2,
       panelWidth,
       panelHeight,
-      DS.hexToNumber(DS.COLORS.solid.bgElevated),
+      DS.colorStringToNumber(colors.bgElevated),
       0.95
     );
-    this.panel.setStrokeStyle(1, DS.hexToNumber(DS.COLORS.glass.border));
+    this.panel.setStrokeStyle(1, DS.colorStringToNumber(colors.glassBorder));
     this.add(this.panel);
 
     // Game Over title with Inter Black font
     this.gameOverText = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + DS.SPACING.xxl,
+      height / 2 - panelHeight / 2 + spacing.xxl,
       'GAME OVER',
       {
-        fontSize: DS.TYPOGRAPHY.fontSize['3xl'],
-        fontFamily: DS.TYPOGRAPHY.fontFamily.displayBlack,
+        fontSize: DS.getFontSize('3xl'),
+        fontFamily: DS.getFontFamily('displayBlack'),
         fontStyle: '900 normal', // Inter Black
-        color: DS.COLORS.solid.danger,
+        color: colors.danger,
         align: 'center'
       }
     ).setOrigin(0.5);
@@ -69,13 +86,13 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     // Score display with bold Inter font
     this.scoreText = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + DS.SPACING.xxl + DS.SPACING.xxxl,
+      height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl,
       'Score: 0',
       {
-        fontSize: DS.TYPOGRAPHY.fontSize['2xl'],
-        fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+        fontSize: DS.getFontSize('2xl'),
+        fontFamily: DS.getFontFamily('display'),
         fontStyle: '700 normal', // Bold
-        color: DS.COLORS.solid.textPrimary,
+        color: colors.textPrimary,
         align: 'center'
       }
     ).setOrigin(0.5);
@@ -84,10 +101,10 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     // Best score display with consistent spacing
     this.bestScoreText = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + DS.SPACING.xxl + DS.SPACING.xxxl + DS.SPACING.xl,
+      height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl + spacing.xl,
       'Best: 0',
       DS.getTextStyle('body', {
-        color: DS.COLORS.solid.warning,
+        color: colors.warning,
         weight: 'medium'
       })
     ).setOrigin(0.5);
@@ -96,10 +113,10 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     // Daily rank display with modern font
     this.dailyRankText = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + DS.SPACING.xxl + DS.SPACING.xxxl + DS.SPACING.xxxl,
+      height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl + spacing.xxxl,
       'Daily Rank: Loading...',
       DS.getTextStyle('caption', {
-        color: DS.COLORS.solid.info,
+        color: colors.info,
         weight: 'regular'
       })
     ).setOrigin(0.5);
@@ -109,9 +126,9 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     this.leaderboardButton = this.createButton(
       scene,
       width / 2,
-      height / 2 + DS.SPACING.xl,
+      height / 2 + spacing.xl,
       'Leaderboard',
-      DS.hexToNumber(DS.COLORS.solid.info),
+      colors.info,
       () => {
         this.emit('showLeaderboard');
       }
@@ -122,9 +139,9 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     this.tryAgainButton = this.createButton(
       scene,
       width / 2,
-      height / 2 + DS.SPACING.xl + DS.SPACING.xxxl,
+      height / 2 + spacing.xl + spacing.xxxl,
       'Try Again',
-      DS.hexToNumber(DS.COLORS.solid.success),
+      colors.success,
       () => {
         this.emit('tryAgain');
         this.hide();
@@ -147,21 +164,21 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     x: number,
     y: number,
     text: string,
-    color: number,
+    color: string,
     onClick: () => void
   ): Phaser.GameObjects.Container {
     const button = scene.add.container(x, y);
 
     const buttonWidth = 200;
-    const buttonHeight = DS.SPACING.xxl;
+    const buttonHeight = DS.getSpacingValue('xxl');
 
-    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, color, 0.9);
-    bg.setStrokeStyle(1, DS.hexToNumber(DS.COLORS.glass.border));
+    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, DS.colorStringToNumber(color), 0.9);
+    bg.setStrokeStyle(1, DS.colorStringToNumber(DS.getColor('glass', 'border')));
     bg.setInteractive();
 
     const label = scene.add.text(0, 0, text,
       DS.getTextStyle('button', {
-        color: DS.COLORS.solid.textPrimary,
+        color: DS.getColor('solid', 'textPrimary'),
         weight: 'medium'
       })
     ).setOrigin(0.5);

--- a/src/client/game/presentation/ui/GradientText.ts
+++ b/src/client/game/presentation/ui/GradientText.ts
@@ -24,7 +24,7 @@ export class GradientText extends Phaser.GameObjects.Container {
     // Create the main text with Inter Black (900 weight)
     this.mainText = scene.add.text(0, 0, text, {
       ...style,
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontFamily: DS.getFontFamily('display'),
       fontStyle: '900 normal', // Inter Black weight
     });
     this.mainText.setOrigin(0.5, 0.5);
@@ -225,7 +225,7 @@ export function createGradientText(
 
   const style: Phaser.Types.GameObjects.Text.TextStyle = {
     fontSize,
-    fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+    fontFamily: DS.getFontFamily('display'),
     fontStyle: '900 normal', // Inter Black
     align: 'center'
   };

--- a/src/client/game/presentation/ui/LeaderboardUI.ts
+++ b/src/client/game/presentation/ui/LeaderboardUI.ts
@@ -20,13 +20,45 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
 
     const { width, height } = scene.cameras.main;
 
+    const spacing = {
+      xl: DS.getSpacingValue('xl'),
+      xxl: DS.getSpacingValue('xxl'),
+      sm: DS.getSpacingValue('sm'),
+      xs: DS.getSpacingValue('xs'),
+    };
+
+    const palette = {
+      overlay: DS.getColor('solid', 'bgPrimary'),
+      panel: DS.getColor('solid', 'bgElevated'),
+      border: DS.getColor('glass', 'border'),
+      warning: DS.getColor('solid', 'warning'),
+      textPrimary: DS.getColor('solid', 'textPrimary'),
+      textMuted: DS.getColor('solid', 'textMuted'),
+      toggleText: DS.getColor('accents', 'teal'),
+      toggleBackground: DS.getColor('accents', 'midnight'),
+      close: DS.getColor('accents', 'coral'),
+      highlight: DS.getColor('accents', 'teal'),
+      highlightSecondary: DS.getColor('accents', 'grayLighter'),
+      separator: DS.getColor('accents', 'grayMuted'),
+    };
+
+    const typography = {
+      displayBlack: DS.getFontFamily('displayBlack'),
+      mono: DS.getFontFamily('mono'),
+    };
+
+    const togglePaddingX = spacing.sm + spacing.xs / 2;
+    const togglePaddingY = spacing.xs + spacing.xs / 4;
+    const closePadding = spacing.xs + spacing.xs / 4;
+    const toggleOffsetY = spacing.xxl + spacing.sm + spacing.xs * 2;
+
     // Semi-transparent background overlay with modern blur
     this.background = scene.add.rectangle(
       width / 2,
       height / 2,
       width,
       height,
-      DS.hexToNumber(DS.COLORS.solid.bgPrimary),
+      DS.colorStringToNumber(palette.overlay),
       0.85
     );
     this.background.setInteractive();
@@ -40,22 +72,22 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
       height / 2,
       panelWidth,
       panelHeight,
-      DS.hexToNumber(DS.COLORS.solid.bgElevated),
+      DS.colorStringToNumber(palette.panel),
       0.95
     );
-    panel.setStrokeStyle(1, DS.hexToNumber(DS.COLORS.glass.border));
+    panel.setStrokeStyle(1, DS.colorStringToNumber(palette.border));
     this.add(panel);
 
     // Title with Inter Black font
     this.titleText = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + DS.SPACING.xl,
+      height / 2 - panelHeight / 2 + spacing.xl,
       'LEADERBOARD',
       {
-        fontSize: DS.TYPOGRAPHY.fontSize['2xl'],
-        fontFamily: DS.TYPOGRAPHY.fontFamily.displayBlack,
+        fontSize: DS.getFontSize('2xl'),
+        fontFamily: typography.displayBlack,
         fontStyle: '900 normal', // Inter Black
-        color: DS.COLORS.solid.warning,
+        color: palette.warning,
         align: 'center'
       }
     ).setOrigin(0.5);
@@ -64,14 +96,14 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
     // Type toggle button
     this.typeToggle = scene.add.text(
       width / 2,
-      height / 2 - panelHeight / 2 + 65,
+      height / 2 - panelHeight / 2 + toggleOffsetY,
       'Global Rankings',
       {
-        fontSize: '16px',
-        fontFamily: 'monospace',
-        color: '#4ECDC4',
-        backgroundColor: '#0f0f1e',
-        padding: { x: 10, y: 5 }
+        fontSize: DS.getFontSize('base'),
+        fontFamily: typography.mono,
+        color: palette.toggleText,
+        backgroundColor: palette.toggleBackground,
+        padding: { x: togglePaddingX, y: togglePaddingY }
       }
     ).setOrigin(0.5).setInteractive();
 
@@ -96,9 +128,9 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
       height / 2,
       'Loading...',
       {
-        fontSize: '20px',
-        fontFamily: 'monospace',
-        color: '#FFFFFF'
+        fontSize: DS.getFontSize('lg'),
+        fontFamily: typography.mono,
+        color: palette.textPrimary
       }
     ).setOrigin(0.5).setVisible(false);
     this.add(this.loadingText);
@@ -109,10 +141,10 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
       height / 2 - panelHeight / 2 + 20,
       '✕',
       {
-        fontSize: '24px',
-        fontFamily: 'monospace',
-        color: '#FF6B6B',
-        padding: { x: 5, y: 5 }
+        fontSize: DS.getFontSize('xl'),
+        fontFamily: typography.mono,
+        color: palette.close,
+        padding: { x: closePadding, y: closePadding }
       }
     ).setOrigin(0.5).setInteractive();
 
@@ -194,6 +226,15 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
     this.entriesContainer.removeAll(true);
     this.loadingText.setVisible(true);
 
+    const spacingXl = DS.getSpacingValue('xl');
+    const spacingXxl = DS.getSpacingValue('xxl');
+    const spacingXs = DS.getSpacingValue('xs');
+    const monoFont = DS.getFontFamily('mono');
+    const highlightColor = DS.getColor('accents', 'teal');
+    const textPrimary = DS.getColor('solid', 'textPrimary');
+    const separatorColor = DS.getColor('accents', 'grayMuted');
+    const errorColor = DS.getColor('accents', 'coral');
+
     try {
       const entries = await highScoreService.getLeaderboard(this.currentType, 10);
       this.loadingText.setVisible(false);
@@ -204,7 +245,7 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
           0,
           'No scores yet. Be the first!',
           DS.getTextStyle('body', {
-            color: DS.COLORS.solid.textMuted
+            color: DS.getColor('solid', 'textMuted')
           })
         ).setOrigin(0.5);
         this.entriesContainer.add(noDataText);
@@ -212,13 +253,13 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
       }
 
       // Display entries
-      const startY = -120;
-      const spacing = 35;
+      const startY = -(spacingXxl * 2 + spacingXl / 2);
+      const entrySpacing = spacingXl + spacingXs;
       const currentUser = highScoreService.getUsername();
 
       entries.forEach((entry, index) => {
         const isCurrentUser = entry.username === currentUser;
-        const yPos = startY + index * spacing;
+        const yPos = startY + index * entrySpacing;
 
         // Rank
         const rankText = this.scene.add.text(
@@ -226,8 +267,8 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
           yPos,
           `#${entry.rank}`,
           {
-            fontSize: '18px',
-            fontFamily: 'monospace',
+            fontSize: DS.getFontSize('lg'),
+            fontFamily: monoFont,
             fontStyle: entry.rank <= 3 ? 'bold' : 'normal',
             color: this.getRankColor(entry.rank)
           }
@@ -239,10 +280,10 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
           yPos,
           entry.username.substring(0, 15),
           {
-            fontSize: '16px',
-            fontFamily: 'monospace',
+            fontSize: DS.getFontSize('base'),
+            fontFamily: monoFont,
             fontStyle: isCurrentUser ? 'bold' : 'normal',
-            color: isCurrentUser ? '#4ECDC4' : '#FFFFFF'
+            color: isCurrentUser ? highlightColor : textPrimary
           }
         ).setOrigin(0, 0.5);
 
@@ -252,10 +293,10 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
           yPos,
           entry.score.toLocaleString(),
           {
-            fontSize: '18px',
-            fontFamily: 'monospace',
+            fontSize: DS.getFontSize('lg'),
+            fontFamily: monoFont,
             fontStyle: 'bold',
-            color: '#FFD700'
+            color: DS.getColor('accents', 'gold')
           }
         ).setOrigin(1, 0.5);
 
@@ -266,10 +307,11 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
             yPos,
             300,
             30,
-            0x4ECDC4,
+            DS.colorStringToNumber(highlightColor),
             0.1
           );
-          highlight.setStrokeStyle(1, 0x4ECDC4, 0.3);
+          const highlightStroke = DS.colorStringToNumber(highlightColor);
+          highlight.setStrokeStyle(1, highlightStroke, 0.3);
           this.entriesContainer.add(highlight);
         }
 
@@ -281,24 +323,24 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
       if (userRank && userRank > 10) {
         const separator = this.scene.add.text(
           0,
-          startY + entries.length * spacing + 10,
+          startY + entries.length * entrySpacing + spacingXs * 2.5,
           '···',
           {
-            fontSize: '16px',
-            fontFamily: 'monospace',
-            color: '#666666'
+            fontSize: DS.getFontSize('base'),
+            fontFamily: monoFont,
+            color: separatorColor
           }
         ).setOrigin(0.5);
 
         const userEntry = this.scene.add.text(
           0,
-          startY + entries.length * spacing + 40,
+          startY + entries.length * entrySpacing + spacingXl,
           `Your Rank: #${userRank}`,
           {
-            fontSize: '16px',
-            fontFamily: 'monospace',
+            fontSize: DS.getFontSize('base'),
+            fontFamily: monoFont,
             fontStyle: 'bold',
-            color: '#4ECDC4'
+            color: highlightColor
           }
         ).setOrigin(0.5);
 
@@ -307,7 +349,7 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
     } catch (error) {
       console.error('Failed to load leaderboard:', error);
       this.loadingText.setText('Failed to load scores');
-      this.loadingText.setColor('#FF6B6B');
+      this.loadingText.setColor(errorColor);
     }
   }
 
@@ -316,10 +358,14 @@ export class LeaderboardUI extends Phaser.GameObjects.Container {
    */
   private getRankColor(rank: number): string {
     switch (rank) {
-      case 1: return '#f5af19'; // Gold gradient start
-      case 2: return '#b8b8b8'; // Silver
-      case 3: return '#cd7f32'; // Bronze
-      default: return DS.COLORS.solid.textPrimary;
+      case 1:
+        return DS.getColor('accents', 'gold');
+      case 2:
+        return DS.getColor('accents', 'silver');
+      case 3:
+        return DS.getColor('accents', 'bronze');
+      default:
+        return DS.getColor('solid', 'textPrimary');
     }
   }
 

--- a/src/client/game/presentation/ui/ModernLeaderboardUI.ts
+++ b/src/client/game/presentation/ui/ModernLeaderboardUI.ts
@@ -51,10 +51,14 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     const { width, height } = scene.cameras.main;
 
+    const palette = this.getPalette();
+    const displayFont = DS.getFontFamily('display');
+    const bodyFont = DS.getFontFamily('body');
+
     // Dark overlay background
     this.background = scene.add.rectangle(
       width / 2, height / 2, width, height,
-      0x000000, 0.8
+      DS.colorStringToNumber(palette.overlay), 0.8
     );
     this.background.setInteractive();
     this.add(this.background);
@@ -66,9 +70,9 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.panel = scene.add.rectangle(
       width / 2, height / 2,
       panelWidth, panelHeight,
-      DS.hexToNumber('#1a1a2e'), 1
+      DS.colorStringToNumber(palette.panelBackground), 1
     );
-    this.panel.setStrokeStyle(2, DS.hexToNumber('#667eea'), 0.3);
+    this.panel.setStrokeStyle(2, DS.colorStringToNumber(palette.panelBorder), 0.3);
     this.add(this.panel);
 
     // Title with gradient effect
@@ -76,10 +80,10 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
       width / 2, height / 2 - panelHeight / 2 + 40,
       'LEADERBOARD',
       {
-        fontSize: '32px',
-        fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+        fontSize: DS.getFontSize('2xl'),
+        fontFamily: displayFont,
         fontStyle: '900 normal',
-        color: '#ffffff'
+        color: palette.textPrimary
       }
     ).setOrigin(0.5);
     this.add(this.titleText);
@@ -121,17 +125,17 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     // Loading indicator
     this.loadingText = scene.add.text(0, 0, 'Loading...', {
-      fontSize: '18px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#888888'
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: bodyFont,
+      color: palette.gray
     }).setOrigin(0.5).setVisible(false);
     this.contentContainer.add(this.loadingText);
 
     // Empty state
     this.emptyText = scene.add.text(0, 0, 'No scores yet.\nBe the first!', {
-      fontSize: '18px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#666666',
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: bodyFont,
+      color: palette.grayMuted,
       align: 'center'
     }).setOrigin(0.5).setVisible(false);
     this.contentContainer.add(this.emptyText);
@@ -151,27 +155,28 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
   private createCloseButton(scene: Phaser.Scene, x: number, y: number): void {
     this.closeButton = scene.add.container(x, y);
 
-    const bg = scene.add.circle(0, 0, 20, DS.hexToNumber('#2a2a3e'), 1);
-    bg.setStrokeStyle(1, DS.hexToNumber('#667eea'), 0.3);
+    const palette = this.getPalette();
+    const bg = scene.add.circle(0, 0, 20, DS.colorStringToNumber(palette.closeBg), 1);
+    bg.setStrokeStyle(1, DS.colorStringToNumber(palette.panelBorder), 0.3);
     bg.setInteractive();
 
     const closeX = scene.add.text(0, 0, '✕', {
-      fontSize: '20px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#888888'
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: DS.getFontFamily('body'),
+      color: palette.closeText
     }).setOrigin(0.5);
 
     this.closeButton.add([bg, closeX]);
 
     bg.on('pointerover', () => {
-      bg.setFillStyle(DS.hexToNumber('#3a3a4e'));
-      closeX.setColor('#ffffff');
+      bg.setFillStyle(DS.colorStringToNumber(palette.closeBgHover));
+      closeX.setColor(palette.textPrimary);
       scene.input.setDefaultCursor('pointer');
     });
 
     bg.on('pointerout', () => {
-      bg.setFillStyle(DS.hexToNumber('#2a2a3e'));
-      closeX.setColor('#888888');
+      bg.setFillStyle(DS.colorStringToNumber(palette.closeBg));
+      closeX.setColor(palette.closeText);
       scene.input.setDefaultCursor('default');
     });
 
@@ -188,12 +193,13 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     const tabWidth = (panelWidth - 60) / 3;
     const tabHeight = 40;
+    const palette = this.getPalette();
 
     // Tab indicator (animated underline)
     this.tabIndicator = scene.add.rectangle(
       -tabWidth - 10, tabHeight / 2 + 5,
       tabWidth - 20, 3,
-      DS.hexToNumber('#667eea'), 1
+      DS.colorStringToNumber(palette.highlight), 1
     );
     this.tabContainer.add(this.tabIndicator);
 
@@ -227,15 +233,17 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     width: number
   ): Phaser.GameObjects.Container {
     const tab = scene.add.container(x, y);
+    const palette = this.getPalette();
+    const displayFont = DS.getFontFamily('display');
 
     const bg = scene.add.rectangle(0, 0, width - 20, 35, 0x000000, 0);
     bg.setInteractive();
 
     const text = scene.add.text(0, 0, label, {
-      fontSize: '14px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('sm'),
+      fontFamily: displayFont,
       fontStyle: '700 normal',
-      color: type === this.activeTab ? '#ffffff' : '#666666'
+      color: type === this.activeTab ? palette.textPrimary : palette.grayMuted
     }).setOrigin(0.5);
 
     tab.add([bg, text]);
@@ -244,14 +252,14 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     bg.on('pointerover', () => {
       if (type !== this.activeTab) {
-        text.setColor('#aaaaaa');
+        text.setColor(palette.grayLight);
         scene.input.setDefaultCursor('pointer');
       }
     });
 
     bg.on('pointerout', () => {
       if (type !== this.activeTab) {
-        text.setColor('#666666');
+        text.setColor(palette.grayMuted);
         scene.input.setDefaultCursor('default');
       }
     });
@@ -272,10 +280,11 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.activeTab = type;
 
     // Update tab text colors
+    const palette = this.getPalette();
     [this.dailyTab, this.weeklyTab, this.allTimeTab].forEach(tab => {
       const tabType = tab.getData('type') as LeaderboardType;
       const text = tab.getData('text') as Phaser.GameObjects.Text;
-      text.setColor(tabType === type ? '#ffffff' : '#666666');
+      text.setColor(tabType === type ? palette.textPrimary : palette.grayMuted);
     });
 
     // Animate indicator
@@ -313,49 +322,56 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     width: number
   ): Phaser.GameObjects.Container {
     const row = scene.add.container(0, y);
+    const palette = this.getPalette();
+    const displayFont = DS.getFontFamily('display');
+    const bodyFont = DS.getFontFamily('body');
 
     // Background for current user
     if (entry.isCurrentUser) {
-      const bg = scene.add.rectangle(0, 0, width - 40, 50, DS.hexToNumber('#667eea'), 0.1);
-      bg.setStrokeStyle(1, DS.hexToNumber('#667eea'), 0.3);
+      const highlightColor = DS.colorStringToNumber(palette.highlight);
+      const bg = scene.add.rectangle(0, 0, width - 40, 50, highlightColor, 0.1);
+      bg.setStrokeStyle(1, highlightColor, 0.3);
       row.add(bg);
     }
 
     // Rank badge
     const rankBg = scene.add.circle(-width / 2 + 50, 0, 18, 0x000000, 0);
     if (entry.rank <= 3) {
-      const colors = ['#ffd700', '#c0c0c0', '#cd7f32']; // Gold, Silver, Bronze
-      rankBg.setFillStyle(DS.hexToNumber(colors[entry.rank - 1]), 0.2);
-      rankBg.setStrokeStyle(2, DS.hexToNumber(colors[entry.rank - 1]), 0.8);
+      const colors = [palette.gold, palette.silver, palette.bronze];
+      const colorValue = DS.colorStringToNumber(colors[entry.rank - 1]);
+      rankBg.setFillStyle(colorValue, 0.2);
+      rankBg.setStrokeStyle(2, colorValue, 0.8);
     } else {
-      rankBg.setStrokeStyle(1, DS.hexToNumber('#444455'), 0.5);
+      rankBg.setStrokeStyle(1, DS.colorStringToNumber(palette.highlightBorder), 0.5);
     }
     row.add(rankBg);
 
     const rankText = scene.add.text(-width / 2 + 50, 0, entry.rank.toString(), {
-      fontSize: entry.rank <= 3 ? '18px' : '16px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: entry.rank <= 3 ? DS.getFontSize('lg') : DS.getFontSize('base'),
+      fontFamily: displayFont,
       fontStyle: '700 normal',
-      color: entry.rank <= 3 ? ['#ffd700', '#c0c0c0', '#cd7f32'][entry.rank - 1] : '#888888'
+      color: entry.rank <= 3
+        ? [palette.gold, palette.silver, palette.bronze][entry.rank - 1]
+        : palette.gray
     }).setOrigin(0.5);
     row.add(rankText);
 
     // Username
     const username = scene.add.text(-width / 2 + 100, 0, entry.username, {
-      fontSize: '16px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
+      fontSize: DS.getFontSize('base'),
+      fontFamily: bodyFont,
       fontStyle: entry.isCurrentUser ? '600 normal' : '400 normal',
-      color: entry.isCurrentUser ? '#ffffff' : '#cccccc'
+      color: entry.isCurrentUser ? palette.textPrimary : palette.grayLighter
     }).setOrigin(0, 0.5);
     row.add(username);
 
     // Score with gradient for top 3
     const scoreColor = entry.rank <= 3 ?
-      ['#ffd700', '#c0c0c0', '#cd7f32'][entry.rank - 1] : '#888888';
+      [palette.gold, palette.silver, palette.bronze][entry.rank - 1] : palette.gray;
 
     const score = scene.add.text(width / 2 - 50, 0, entry.score.toLocaleString(), {
-      fontSize: '18px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: displayFont,
       fontStyle: '600 normal',
       color: scoreColor
     }).setOrigin(1, 0.5);
@@ -646,22 +662,24 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
    */
   private createPlayerPositionDisplay(scene: Phaser.Scene, x: number, y: number, panelWidth: number): void {
     this.playerPositionContainer = scene.add.container(x, y);
+    const palette = this.getPalette();
+    const displayFont = DS.getFontFamily('display');
 
     // Background bar
     this.playerPositionBg = scene.add.rectangle(
       0, 0,
       panelWidth - 40, 60,
-      DS.hexToNumber('#2a2a3e'), 1
+      DS.colorStringToNumber(palette.closeBg), 1
     );
-    this.playerPositionBg.setStrokeStyle(1, DS.hexToNumber('#667eea'), 0.5);
+    this.playerPositionBg.setStrokeStyle(1, DS.colorStringToNumber(palette.panelBorder), 0.5);
     this.playerPositionContainer.add(this.playerPositionBg);
 
     // Player rank text
     this.playerPositionText = scene.add.text(0, 0, 'Your Rank: Calculating...', {
-      fontSize: '18px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: displayFont,
       fontStyle: '600 normal',
-      color: '#ffffff'
+      color: palette.textPrimary
     }).setOrigin(0.5);
     this.playerPositionContainer.add(this.playerPositionText);
 
@@ -676,6 +694,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
       const { highScoreService } = await import('../../../services/HighScoreService');
       const currentUsername = highScoreService.getUsername();
       const currentScore = this.currentPlayerScore || 0;
+      const palette = this.getPalette();
 
       // Find player in entries
       const playerEntry = entries.find(e => e.username === currentUsername);
@@ -683,7 +702,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
       if (playerEntry) {
         // Player is in the visible leaderboard
         this.playerPositionText.setText(`Your Rank: #${playerEntry.rank} • Score: ${playerEntry.score.toLocaleString()}`);
-        this.playerPositionText.setColor('#667eea');
+        this.playerPositionText.setColor(palette.highlight);
       } else if (currentScore > 0) {
         // Calculate rank based on score
         let calculatedRank = entries.length + 1;
@@ -696,22 +715,49 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
         if (calculatedRank <= entries.length) {
           this.playerPositionText.setText(`Your Rank: #${calculatedRank} • Score: ${currentScore.toLocaleString()}`);
-          this.playerPositionText.setColor('#888888');
+          this.playerPositionText.setColor(palette.gray);
         } else {
           // Player is below all entries
           const estimatedRank = Math.floor(entries.length * 1.5 + Math.random() * 50);
           this.playerPositionText.setText(`Your Rank: ~#${estimatedRank} • Score: ${currentScore.toLocaleString()}`);
-          this.playerPositionText.setColor('#666666');
+          this.playerPositionText.setColor(palette.grayMuted);
         }
       } else {
         this.playerPositionText.setText('Play to get ranked!');
-        this.playerPositionText.setColor('#666666');
+        this.playerPositionText.setColor(palette.grayMuted);
       }
     } catch (error) {
       console.error('Failed to update player position:', error);
       this.playerPositionText.setText('Rank unavailable');
-      this.playerPositionText.setColor('#666666');
+      this.playerPositionText.setColor(palette.grayMuted);
     }
+  }
+
+  private getPalette() {
+    return {
+      overlay: DS.getColor('solid', 'bgPrimary'),
+      panelBackground: DS.getColor('accents', 'indigoSurface'),
+      panelBorder: DS.getColor('accents', 'indigo'),
+      textPrimary: DS.getColor('solid', 'textPrimary'),
+      textMuted: DS.getColor('accents', 'gray'),
+      textSubtle: DS.getColor('accents', 'grayMuted'),
+      textSecondary: DS.getColor('accents', 'grayLight'),
+      closeBg: DS.getColor('accents', 'indigoSurface'),
+      closeBgHover: DS.getColor('accents', 'indigoSurfaceHover'),
+      closeText: DS.getColor('accents', 'gray'),
+      highlight: DS.getColor('accents', 'indigo'),
+      highlightSurface: DS.getColor('accents', 'indigoSurface'),
+      highlightHover: DS.getColor('accents', 'indigoSurfaceHover'),
+      highlightBorder: DS.getColor('accents', 'indigoSurfaceBorder'),
+      gold: DS.getColor('accents', 'gold'),
+      silver: DS.getColor('accents', 'silver'),
+      bronze: DS.getColor('accents', 'bronze'),
+      gray: DS.getColor('accents', 'gray'),
+      grayLight: DS.getColor('accents', 'grayLight'),
+      grayLighter: DS.getColor('accents', 'grayLighter'),
+      grayMuted: DS.getColor('accents', 'grayMuted'),
+      blueSoft: DS.getColor('accents', 'blueSoft'),
+    };
   }
 
   /**

--- a/src/client/game/presentation/ui/SettingsUI.ts
+++ b/src/client/game/presentation/ui/SettingsUI.ts
@@ -31,10 +31,45 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
     const { width, height } = scene.cameras.main;
 
+    const spacing = {
+      xl: DS.getSpacingValue('xl'),
+      lg: DS.getSpacingValue('lg'),
+      md: DS.getSpacingValue('md'),
+      base: DS.getSpacingValue('sm'),
+    };
+
+    const palette = {
+      overlay: DS.getColor('solid', 'bgPrimary'),
+      panelBackground: DS.getColor('accents', 'indigoSurface'),
+      panelBorder: DS.getColor('accents', 'indigo'),
+      title: DS.getColor('solid', 'textPrimary'),
+      closeBg: DS.getColor('accents', 'indigoSurface'),
+      closeBgHover: DS.getColor('accents', 'indigoSurfaceHover'),
+      closeText: DS.getColor('accents', 'gray'),
+      sectionLabel: DS.getColor('accents', 'gray'),
+      usernameCustom: DS.getColor('accents', 'indigo'),
+      usernameDefault: DS.getColor('accents', 'grayLight'),
+      redditLabel: DS.getColor('accents', 'grayMuted'),
+      inputBg: DS.getColor('accents', 'indigoSurface'),
+      inputBorder: DS.getColor('accents', 'indigo'),
+      buttonPrimary: DS.getColor('accents', 'indigo'),
+      buttonDanger: DS.getColor('accents', 'crimson'),
+      buttonSuccess: DS.getColor('accents', 'mint'),
+      statusDanger: DS.getColor('accents', 'crimson'),
+      statusSuccess: DS.getColor('accents', 'mint'),
+      statusWarning: DS.getColor('accents', 'amber'),
+    };
+
+    const fonts = {
+      display: DS.getFontFamily('display'),
+      displayBlack: DS.getFontFamily('displayBlack'),
+      body: DS.getFontFamily('body'),
+    };
+
     // Dark overlay background
     this.background = scene.add.rectangle(
       width / 2, height / 2, width, height,
-      0x000000, 0.8
+      DS.colorStringToNumber(palette.overlay), 0.8
     );
     this.background.setInteractive();
     this.add(this.background);
@@ -46,20 +81,20 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.panel = scene.add.rectangle(
       width / 2, height / 2,
       panelWidth, panelHeight,
-      DS.hexToNumber('#1a1a2e'), 1
+      DS.colorStringToNumber(palette.panelBackground), 1
     );
-    this.panel.setStrokeStyle(2, DS.hexToNumber('#667eea'), 0.3);
+    this.panel.setStrokeStyle(2, DS.colorStringToNumber(palette.panelBorder), 0.3);
     this.add(this.panel);
 
     // Title
     this.titleText = scene.add.text(
-      width / 2, height / 2 - panelHeight / 2 + 40,
+      width / 2, height / 2 - panelHeight / 2 + spacing.xl + spacing.base,
       'SETTINGS',
       {
-        fontSize: '28px',
-        fontFamily: DS.TYPOGRAPHY.fontFamily.displayBlack,
+        fontSize: DS.getFontSize('xl'),
+        fontFamily: fonts.displayBlack,
         fontStyle: '900 normal',
-        color: '#ffffff'
+        color: palette.title
       }
     ).setOrigin(0.5);
     this.add(this.titleText);
@@ -77,7 +112,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 + 20,
       '🏆 LEADERBOARD',
-      DS.hexToNumber('#667eea'),
+      DS.getColor('accents', 'indigo'),
       () => {
         this.hide();
         this.emit('showLeaderboard');
@@ -91,7 +126,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 + 80,
       '🔄 RESET GAME',
-      DS.hexToNumber('#dc2626'),
+      DS.getColor('accents', 'crimson'),
       () => {
         this.confirmReset(scene);
       }
@@ -110,27 +145,27 @@ export class SettingsUI extends Phaser.GameObjects.Container {
   private createCloseButton(scene: Phaser.Scene, x: number, y: number): void {
     this.closeButton = scene.add.container(x, y);
 
-    const bg = scene.add.circle(0, 0, 20, DS.hexToNumber('#2a2a3e'), 1);
-    bg.setStrokeStyle(1, DS.hexToNumber('#667eea'), 0.3);
+    const bg = scene.add.circle(0, 0, 20, DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')), 1);
+    bg.setStrokeStyle(1, DS.colorStringToNumber(DS.getColor('accents', 'indigo')), 0.3);
     bg.setInteractive();
 
     const closeX = scene.add.text(0, 0, '✕', {
-      fontSize: '20px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#888888'
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: DS.getFontFamily('body'),
+      color: DS.getColor('accents', 'gray')
     }).setOrigin(0.5);
 
     this.closeButton.add([bg, closeX]);
 
     bg.on('pointerover', () => {
-      bg.setFillStyle(DS.hexToNumber('#3a3a4e'));
-      closeX.setColor('#ffffff');
+      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigoSurfaceHover')));
+      closeX.setColor(DS.getColor('solid', 'textPrimary'));
       scene.input.setDefaultCursor('pointer');
     });
 
     bg.on('pointerout', () => {
-      bg.setFillStyle(DS.hexToNumber('#2a2a3e'));
-      closeX.setColor('#888888');
+      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')));
+      closeX.setColor(DS.getColor('accents', 'gray'));
       scene.input.setDefaultCursor('default');
     });
 
@@ -145,10 +180,10 @@ export class SettingsUI extends Phaser.GameObjects.Container {
   private createUsernameSection(scene: Phaser.Scene, x: number, y: number, panelWidth: number): void {
     // Section title
     const sectionTitle = scene.add.text(x, y, 'USERNAME', {
-      fontSize: '14px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('sm'),
+      fontFamily: DS.getFontFamily('display'),
       fontStyle: '600 normal',
-      color: '#888888'
+      color: DS.getColor('accents', 'gray')
     }).setOrigin(0.5);
     this.add(sectionTitle);
 
@@ -157,19 +192,19 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const isCustom = highScoreService.hasCustomUsername();
 
     this.currentUsernameText = scene.add.text(x, y + 30, currentUsername, {
-      fontSize: '20px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: DS.getFontFamily('display'),
       fontStyle: '700 normal',
-      color: isCustom ? '#667eea' : '#aaaaaa'
+      color: isCustom ? DS.getColor('accents', 'indigo') : DS.getColor('accents', 'grayLight')
     }).setOrigin(0.5);
     this.add(this.currentUsernameText);
 
     // Reddit username indicator
     if (!isCustom) {
       const redditLabel = scene.add.text(x, y + 55, '(Reddit Username)', {
-        fontSize: '12px',
-        fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-        color: '#666666'
+        fontSize: DS.getFontSize('sm'),
+        fontFamily: DS.getFontFamily('body'),
+        color: DS.getColor('accents', 'grayMuted')
       }).setOrigin(0.5);
       this.add(redditLabel);
     }
@@ -178,25 +213,25 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.usernameInputBg = scene.add.rectangle(
       x, y + 90,
       panelWidth - 80, 40,
-      DS.hexToNumber('#2a2a3e'), 1
+      DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')), 1
     );
-    this.usernameInputBg.setStrokeStyle(2, DS.hexToNumber('#667eea'), 0.5);
+    this.usernameInputBg.setStrokeStyle(2, DS.colorStringToNumber(DS.getColor('accents', 'indigo')), 0.5);
     this.usernameInputBg.setVisible(false);
     this.add(this.usernameInputBg);
 
     this.usernameInput = scene.add.text(x, y + 90, '', {
-      fontSize: '16px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#ffffff'
+      fontSize: DS.getFontSize('base'),
+      fontFamily: DS.getFontFamily('body'),
+      color: DS.getColor('solid', 'textPrimary')
     }).setOrigin(0.5);
     this.usernameInput.setVisible(false);
     this.add(this.usernameInput);
 
     // Status text
     this.usernameStatusText = scene.add.text(x, y + 130, '', {
-      fontSize: '12px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-      color: '#666666'
+      fontSize: DS.getFontSize('sm'),
+      fontFamily: DS.getFontFamily('body'),
+      color: DS.getColor('accents', 'grayMuted')
     }).setOrigin(0.5).setVisible(false);
     this.add(this.usernameStatusText);
 
@@ -204,7 +239,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.changeUsernameButton = this.createActionButton(
       scene, x, y + 90,
       isCustom ? 'CHANGE USERNAME' : 'SET CUSTOM USERNAME',
-      DS.hexToNumber('#10b981'),
+      DS.getColor('accents', 'mint'),
       () => this.toggleUsernameEdit(scene)
     );
     this.add(this.changeUsernameButton);
@@ -218,7 +253,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     x: number,
     y: number,
     text: string,
-    color: number,
+    color: string,
     onClick: () => void
   ): Phaser.GameObjects.Container {
     const button = scene.add.container(x, y);
@@ -226,15 +261,16 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const buttonWidth = 260;
     const buttonHeight = 45;
 
-    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, color, 0.9);
-    bg.setStrokeStyle(1, color, 0.3);
+    const fillColor = DS.colorStringToNumber(color);
+    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, fillColor, 0.9);
+    bg.setStrokeStyle(1, fillColor, 0.3);
     bg.setInteractive();
 
     const label = scene.add.text(0, 0, text, {
-      fontSize: '16px',
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('base'),
+      fontFamily: DS.getFontFamily('display'),
       fontStyle: '600 normal',
-      color: '#ffffff'
+      color: DS.getColor('solid', 'textPrimary')
     }).setOrigin(0.5);
 
     button.add([bg, label]);
@@ -268,20 +304,20 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       this.usernameInputBg.setVisible(true);
       this.usernameInput.setVisible(true);
       this.usernameInput.setText('Enter new username...');
-      this.usernameInput.setColor('#666666');
+      this.usernameInput.setColor(DS.getColor('accents', 'grayMuted'));
 
       // Update button
       const bg = this.changeUsernameButton.getData('bg') as Phaser.GameObjects.Rectangle;
       const label = this.changeUsernameButton.getData('label') as Phaser.GameObjects.Text;
       label.setText('SAVE USERNAME');
-      bg.setFillStyle(DS.hexToNumber('#667eea'));
+      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigo')));
 
       // Setup keyboard input
       this.setupKeyboardInput(scene);
 
       // Show status
       this.usernameStatusText.setText('3-20 characters, letters/numbers/underscore only');
-      this.usernameStatusText.setColor('#666666');
+      this.usernameStatusText.setColor(DS.getColor('accents', 'grayMuted'));
       this.usernameStatusText.setVisible(true);
     } else {
       // Save username
@@ -323,10 +359,10 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       // Update display
       if (this.pendingUsername.length > 0) {
         this.usernameInput.setText(this.pendingUsername);
-        this.usernameInput.setColor('#ffffff');
+        this.usernameInput.setColor(DS.getColor('solid', 'textPrimary'));
       } else {
         this.usernameInput.setText('Enter new username...');
-        this.usernameInput.setColor('#666666');
+        this.usernameInput.setColor(DS.getColor('accents', 'grayMuted'));
       }
 
       // Validate
@@ -342,24 +378,24 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
     if (username.length < 3) {
       this.usernameStatusText.setText('Username too short (min 3 characters)');
-      this.usernameStatusText.setColor('#dc2626');
+      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
       return;
     }
 
     if (username.length > 20) {
       this.usernameStatusText.setText('Username too long (max 20 characters)');
-      this.usernameStatusText.setColor('#dc2626');
+      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
       return;
     }
 
     if (!/^[a-zA-Z0-9_]+$/.test(username)) {
       this.usernameStatusText.setText('Only letters, numbers, and underscore allowed');
-      this.usernameStatusText.setColor('#dc2626');
+      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
       return;
     }
 
     this.usernameStatusText.setText('✓ Valid username');
-    this.usernameStatusText.setColor('#10b981');
+    this.usernameStatusText.setColor(DS.getColor('accents', 'mint'));
   }
 
   /**
@@ -376,7 +412,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
     // Check uniqueness
     this.usernameStatusText.setText('Checking availability...');
-    this.usernameStatusText.setColor('#f59e0b');
+    this.usernameStatusText.setColor(DS.getColor('accents', 'amber'));
 
     try {
       // Check if username is available
@@ -395,14 +431,14 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
           // Update display
           this.currentUsernameText.setText(username);
-          this.currentUsernameText.setColor('#667eea');
+          this.currentUsernameText.setColor(DS.getColor('accents', 'indigo'));
 
           // Exit edit mode
           this.cancelUsernameEdit();
 
           // Show success
           this.usernameStatusText.setText('✓ Username saved!');
-          this.usernameStatusText.setColor('#10b981');
+          this.usernameStatusText.setColor(DS.getColor('accents', 'mint'));
           this.usernameStatusText.setVisible(true);
 
           // Hide status after 2 seconds
@@ -411,7 +447,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
           });
         } else {
           this.usernameStatusText.setText('Username already taken');
-          this.usernameStatusText.setColor('#dc2626');
+          this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
         }
       } else {
         throw new Error('Failed to check username');
@@ -421,11 +457,11 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       // Allow setting username offline
       highScoreService.setCustomUsername(username);
       this.currentUsernameText.setText(username);
-      this.currentUsernameText.setColor('#667eea');
+      this.currentUsernameText.setColor(DS.getColor('accents', 'indigo'));
       this.cancelUsernameEdit();
 
       this.usernameStatusText.setText('✓ Username saved locally');
-      this.usernameStatusText.setColor('#f59e0b');
+      this.usernameStatusText.setColor(DS.getColor('accents', 'amber'));
       this.usernameStatusText.setVisible(true);
 
       this.scene.time.delayedCall(2000, () => {
@@ -448,7 +484,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const bg = this.changeUsernameButton.getData('bg') as Phaser.GameObjects.Rectangle;
     const label = this.changeUsernameButton.getData('label') as Phaser.GameObjects.Text;
     label.setText(highScoreService.hasCustomUsername() ? 'CHANGE USERNAME' : 'SET CUSTOM USERNAME');
-    bg.setFillStyle(DS.hexToNumber('#10b981'));
+    bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'mint')));
 
     // Clear keyboard listeners
     this.scene.input.keyboard?.removeAllListeners();
@@ -463,9 +499,9 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       scene.cameras.main.height / 2 + 140,
       'Are you sure? This will reset your progress!',
       {
-        fontSize: '14px',
-        fontFamily: DS.TYPOGRAPHY.fontFamily.body,
-        color: '#dc2626'
+        fontSize: DS.getFontSize('sm'),
+        fontFamily: DS.getFontFamily('body'),
+        color: DS.getColor('accents', 'crimson')
       }
     ).setOrigin(0.5);
     this.add(confirmText);

--- a/src/client/game/presentation/ui/ToastUI.ts
+++ b/src/client/game/presentation/ui/ToastUI.ts
@@ -53,41 +53,48 @@ export class ToastUI {
     const { width, height } = this.scene.cameras.main;
     const isDark = this.colorSystem.isDark();
 
+    const displayFont = DS.getFontFamily('display');
+    const spacingXxxl = DS.getSpacingValue('xxxl');
+    const spacingXl = DS.getSpacingValue('xl');
+    const dangerColor = isDark ? DS.getColor('solid', 'danger') : DS.getColor('accents', 'coralMuted');
+    const backgroundColor = isDark ? DS.getColor('solid', 'bgElevated') : DS.getColor('solid', 'textPrimary');
+    const borderColor = isDark ? DS.getColor('solid', 'danger') : DS.getColor('accents', 'coralMuted');
+
     const container = this.scene.add.container(width / 2, height / 2);
     container.setDepth(DS.LAYERS.modal);
 
     // Large text with Inter font
     const text = this.scene.add.text(0, 0, message.toUpperCase(), {
-      fontSize: DS.TYPOGRAPHY.fontSize['4xl'],
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('4xl'),
+      fontFamily: displayFont,
       fontStyle: '700 normal', // Bold
-      color: isDark ? DS.COLORS.solid.danger : '#d44860',
+      color: dangerColor,
       align: 'center'
     }).setOrigin(0.5);
 
     // Add gradient effect for dark mode
     if (isDark) {
-      const gradient = DS.COLORS.gradients.danger;
+      const gradient = DS.getGradient('danger');
       text.setTint(
-        DS.hexToNumber(gradient[0]),
-        DS.hexToNumber(gradient[0]),
-        DS.hexToNumber(gradient[1]),
-        DS.hexToNumber(gradient[1])
+        DS.colorStringToNumber(gradient[0]),
+        DS.colorStringToNumber(gradient[0]),
+        DS.colorStringToNumber(gradient[1]),
+        DS.colorStringToNumber(gradient[1])
       );
     }
 
     // Semi-transparent background
-    const paddingX = DS.SPACING.xxxl;
-    const paddingY = DS.SPACING.xl;
+    const paddingX = spacingXxxl;
+    const paddingY = spacingXl;
     const bgWidth = text.width + paddingX * 2;
     const bgHeight = text.height + paddingY * 2;
 
     const bg = this.scene.add.rectangle(
       0, 0, bgWidth, bgHeight,
-      DS.hexToNumber(isDark ? DS.COLORS.solid.bgElevated : '#ffffff'),
+      DS.colorStringToNumber(backgroundColor),
       isDark ? 0.95 : 0.98
     )
-      .setStrokeStyle(2, DS.hexToNumber(isDark ? DS.COLORS.solid.danger : '#d44860'))
+      .setStrokeStyle(2, DS.colorStringToNumber(borderColor))
       .setOrigin(0.5);
 
     container.add([bg, text]);
@@ -135,39 +142,53 @@ export class ToastUI {
     const { width, height } = this.scene.cameras.main;
     const isDark = this.colorSystem.isDark();
 
+    const displayFont = DS.getFontFamily('display');
+    const bodyFont = DS.getFontFamily('body');
+    const spacingXl = DS.getSpacingValue('xl');
+    const spacingXxxl = DS.getSpacingValue('xxxl');
+    const spacingXxl = DS.getSpacingValue('xxl');
+    const spacingLg = DS.getSpacingValue('lg');
+    const spacingMd = DS.getSpacingValue('md');
+    const spacingXs = DS.getSpacingValue('xs');
+    const successColor = isDark ? DS.getColor('solid', 'success') : DS.getColor('accents', 'successSoft');
+    const gradient = isDark ? DS.getGradient('success') : DS.getGradient('successSoft');
+    const messageColor = isDark ? DS.getColor('solid', 'textSecondary') : DS.getColor('solid', 'textInverseMuted');
+    const backgroundColor = isDark ? DS.getColor('solid', 'bgElevated') : DS.getColor('solid', 'textPrimary');
+    const borderColor = isDark ? DS.getColor('glass', 'border') : DS.getColor('glass', 'borderAccent');
+    const floatOffset = spacingMd + spacingXs;
+
     const container = this.scene.add.container(width / 2, height * 0.4);
     container.setDepth(DS.LAYERS.toast);
 
     // Score text with gradient
     const scoreText = this.scene.add.text(0, 0, `+${score}`, {
-      fontSize: DS.TYPOGRAPHY.fontSize['3xl'],
-      fontFamily: DS.TYPOGRAPHY.fontFamily.display,
+      fontSize: DS.getFontSize('3xl'),
+      fontFamily: displayFont,
       fontStyle: '800 normal', // Extra bold
-      color: isDark ? '#00ff88' : '#00c550',
+      color: successColor,
       align: 'center'
     }).setOrigin(0.5);
 
     // Apply gradient
-    const gradient = isDark ? DS.COLORS.gradients.success : ['#00c550', '#00e560', '#00ff70'];
     scoreText.setTint(
-      DS.hexToNumber(gradient[0]),
-      DS.hexToNumber(gradient[0]),
-      DS.hexToNumber(gradient[2]),
-      DS.hexToNumber(gradient[2])
+      DS.colorStringToNumber(gradient[0]),
+      DS.colorStringToNumber(gradient[0]),
+      DS.colorStringToNumber(gradient[2] ?? gradient[gradient.length - 1]),
+      DS.colorStringToNumber(gradient[2] ?? gradient[gradient.length - 1])
     );
 
     // Message text
-    const msgText = this.scene.add.text(0, DS.SPACING.xl, message, {
-      fontSize: DS.TYPOGRAPHY.fontSize.lg,
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
+    const msgText = this.scene.add.text(0, spacingXl, message, {
+      fontSize: DS.getFontSize('lg'),
+      fontFamily: bodyFont,
       fontStyle: '500 normal',
-      color: isDark ? DS.COLORS.solid.textSecondary : 'rgba(10, 10, 15, 0.7)',
+      color: messageColor,
       align: 'center'
     }).setOrigin(0.5);
 
     container.add([scoreText, msgText]);
     container.setAlpha(0);
-    container.setY(height * 0.4 + 20);
+    container.setY(height * 0.4 + floatOffset);
 
     this.container = container;
 
@@ -215,28 +236,38 @@ export class ToastUI {
     const { width } = this.scene.cameras.main;
     const isDark = this.colorSystem.isDark();
 
-    const container = this.scene.add.container(width / 2, DS.SPACING.xxxl + DS.SPACING.xl);
+    const spacingXxxl = DS.getSpacingValue('xxxl');
+    const spacingXl = DS.getSpacingValue('xl');
+    const spacingLg = DS.getSpacingValue('lg');
+    const spacingMd = DS.getSpacingValue('md');
+    const spacingXxl = DS.getSpacingValue('xxl');
+    const bodyFont = DS.getFontFamily('body');
+    const textColor = isDark ? DS.getColor('solid', 'textPrimary') : DS.getColor('solid', 'textInverse');
+    const backgroundColor = isDark ? DS.getColor('solid', 'bgElevated') : DS.getColor('solid', 'textPrimary');
+    const borderColor = isDark ? DS.getColor('glass', 'border') : DS.getColor('glass', 'borderAccent');
+
+    const container = this.scene.add.container(width / 2, spacingXxxl + spacingXl);
     container.setDepth(DS.LAYERS.toast);
 
     const text = this.scene.add.text(0, 0, message, {
-      fontSize: DS.TYPOGRAPHY.fontSize.base,
-      fontFamily: DS.TYPOGRAPHY.fontFamily.body,
+      fontSize: DS.getFontSize('base'),
+      fontFamily: bodyFont,
       fontStyle: '500 normal',
-      color: isDark ? DS.COLORS.solid.textPrimary : DS.COLORS.solid.textInverse,
+      color: textColor,
       align: 'center'
     }).setOrigin(0.5);
 
-    const paddingX = DS.SPACING.lg;
-    const paddingY = DS.SPACING.md;
-    const bgWidth = Math.max(DS.SPACING.xxxl * 3, text.width + paddingX * 2);
-    const bgHeight = Math.max(DS.SPACING.xxl, text.height + paddingY * 2);
+    const paddingX = spacingLg;
+    const paddingY = spacingMd;
+    const bgWidth = Math.max(spacingXxxl * 3, text.width + paddingX * 2);
+    const bgHeight = Math.max(spacingXxl, text.height + paddingY * 2);
 
     const bg = this.scene.add.rectangle(
       0, 0, bgWidth, bgHeight,
-      DS.hexToNumber(isDark ? DS.COLORS.solid.bgElevated : '#ffffff'),
+      DS.colorStringToNumber(backgroundColor),
       isDark ? 0.95 : 0.98
     )
-      .setStrokeStyle(1, DS.hexToNumber(isDark ? DS.COLORS.glass.border : 'rgba(102, 126, 234, 0.15)'))
+      .setStrokeStyle(1, DS.colorStringToNumber(borderColor))
       .setOrigin(0.5);
 
     container.add([bg, text]);

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -6,6 +6,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lilita+One&display=swap" rel="stylesheet">
+    <style data-theme="hexomind-variables">
+      @import './style.css';
+    </style>
     <link rel="stylesheet" href="style.css" />
     <title>Hexomind</title>
   </head>


### PR DESCRIPTION
## Summary
- expose design system spacing, typography, and color tokens as CSS variables and provide helpers to resolve them at runtime
- update theme provider and UI components to consume CSS variables instead of hard-coded values for consistent palette swaps
- ensure Devvit entrypoint imports the CSS token declarations so hosted containers inherit the design variables

## Testing
- npm run lint *(fails: existing lint errors in project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68c9585bf8948327869cfadbfd24aebb