### PR TITLE
Refactor game UI components to share design system base

### DIFF
--- a/src/client/game/presentation/ui/GameOverUI.ts
+++ b/src/client/game/presentation/ui/GameOverUI.ts
@@ -3,9 +3,9 @@
  */
 import * as Phaser from 'phaser';
 import { highScoreService } from '../../../services/HighScoreService';
-import { DS } from '../../config/DesignSystem';
+import { UIComponent } from './components/UIComponent';
 
-export class GameOverUI extends Phaser.GameObjects.Container {
+export class GameOverUI extends UIComponent {
   private background: Phaser.GameObjects.Rectangle;
   private panel: Phaser.GameObjects.Rectangle;
   private gameOverText: Phaser.GameObjects.Text;
@@ -17,29 +17,25 @@ export class GameOverUI extends Phaser.GameObjects.Container {
   private isVisible: boolean = false;
 
   constructor(scene: Phaser.Scene) {
-    super(scene, 0, 0);
+    super(scene, { visible: false });
+    this.setDepth(2000);
 
     const { width, height } = scene.cameras.main;
 
-    const spacing = {
-      xl: DS.getSpacingValue('xl'),
-      xxl: DS.getSpacingValue('xxl'),
-      xxxl: DS.getSpacingValue('xxxl'),
-    };
+    const spacing = this.spacing;
 
     const colors = {
-      bgPrimary: DS.getColor('solid', 'bgPrimary'),
-      bgElevated: DS.getColor('solid', 'bgElevated'),
-      glassBorder: DS.getColor('glass', 'border'),
-      textPrimary: DS.getColor('solid', 'textPrimary'),
-      danger: DS.getColor('solid', 'danger'),
-      warning: DS.getColor('solid', 'warning'),
-      info: DS.getColor('solid', 'info'),
-      success: DS.getColor('solid', 'success'),
+      bgPrimary: this.getColor('solid', 'bgPrimary'),
+      bgElevated: this.getColor('solid', 'bgElevated'),
+      glassBorder: this.getColor('glass', 'border'),
+      textPrimary: this.getColor('solid', 'textPrimary'),
+      danger: this.getColor('solid', 'danger'),
+      warning: this.getColor('solid', 'warning'),
+      info: this.getColor('solid', 'info'),
+      success: this.getColor('solid', 'success'),
     };
 
     // Ensure this UI sits above everything else and starts hidden
-    this.setDepth(1000);
     this.setVisible(false);
 
     // Semi-transparent background overlay with blur effect
@@ -48,7 +44,7 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2,
       width,
       height,
-      DS.colorStringToNumber(colors.bgPrimary),
+      this.colorToNumber(colors.bgPrimary),
       0.85
     );
     this.background.setInteractive();
@@ -62,10 +58,10 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2,
       panelWidth,
       panelHeight,
-      DS.colorStringToNumber(colors.bgElevated),
+      this.colorToNumber(colors.bgElevated),
       0.95
     );
-    this.panel.setStrokeStyle(1, DS.colorStringToNumber(colors.glassBorder));
+    this.panel.setStrokeStyle(1, this.colorToNumber(colors.glassBorder));
     this.add(this.panel);
 
     // Game Over title with Inter Black font
@@ -74,8 +70,8 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2 - panelHeight / 2 + spacing.xxl,
       'GAME OVER',
       {
-        fontSize: DS.getFontSize('3xl'),
-        fontFamily: DS.getFontFamily('displayBlack'),
+        fontSize: this.getFontSize('3xl'),
+        fontFamily: this.getFontFamily('displayBlack'),
         fontStyle: '900 normal', // Inter Black
         color: colors.danger,
         align: 'center'
@@ -89,8 +85,8 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl,
       'Score: 0',
       {
-        fontSize: DS.getFontSize('2xl'),
-        fontFamily: DS.getFontFamily('display'),
+        fontSize: this.getFontSize('2xl'),
+        fontFamily: this.getFontFamily('display'),
         fontStyle: '700 normal', // Bold
         color: colors.textPrimary,
         align: 'center'
@@ -103,7 +99,7 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl + spacing.xl,
       'Best: 0',
-      DS.getTextStyle('body', {
+      this.getTextStyle('body', {
         color: colors.warning,
         weight: 'medium'
       })
@@ -115,7 +111,7 @@ export class GameOverUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 - panelHeight / 2 + spacing.xxl + spacing.xxxl + spacing.xxxl,
       'Daily Rank: Loading...',
-      DS.getTextStyle('caption', {
+      this.getTextStyle('caption', {
         color: colors.info,
         weight: 'regular'
       })
@@ -151,9 +147,6 @@ export class GameOverUI extends Phaser.GameObjects.Container {
 
     // Initially hidden
     this.setVisible(false);
-    this.setDepth(2000);
-
-    scene.add.existing(this);
   }
 
   /**
@@ -170,15 +163,15 @@ export class GameOverUI extends Phaser.GameObjects.Container {
     const button = scene.add.container(x, y);
 
     const buttonWidth = 200;
-    const buttonHeight = DS.getSpacingValue('xxl');
+    const buttonHeight = this.getSpacing('xxl');
 
-    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, DS.colorStringToNumber(color), 0.9);
-    bg.setStrokeStyle(1, DS.colorStringToNumber(DS.getColor('glass', 'border')));
+    const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, this.colorToNumber(color), 0.9);
+    bg.setStrokeStyle(1, this.colorToNumber(this.getColor('glass', 'border')));
     bg.setInteractive();
 
     const label = scene.add.text(0, 0, text,
-      DS.getTextStyle('button', {
-        color: DS.getColor('solid', 'textPrimary'),
+      this.getTextStyle('button', {
+        color: this.getColor('solid', 'textPrimary'),
         weight: 'medium'
       })
     ).setOrigin(0.5);

--- a/src/client/game/presentation/ui/ModernLeaderboardUI.ts
+++ b/src/client/game/presentation/ui/ModernLeaderboardUI.ts
@@ -1,5 +1,5 @@
 import * as Phaser from 'phaser';
-import { DS } from '../../config/DesignSystem';
+import { UIComponent } from './components/UIComponent';
 
 interface LeaderboardEntry {
   rank: number;
@@ -13,7 +13,7 @@ type LeaderboardType = 'daily' | 'weekly' | 'allTime';
 /**
  * Modern Leaderboard UI with tabs, animations, and beautiful design
  */
-export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
+export class ModernLeaderboardUI extends UIComponent {
   private background: Phaser.GameObjects.Rectangle;
   private panel: Phaser.GameObjects.Rectangle;
   private titleText: Phaser.GameObjects.Text;
@@ -47,18 +47,18 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
   private maxScrollY: number = 0;
 
   constructor(scene: Phaser.Scene) {
-    super(scene, 0, 0);
+    super(scene, { visible: false });
 
     const { width, height } = scene.cameras.main;
 
     const palette = this.getPalette();
-    const displayFont = DS.getFontFamily('display');
-    const bodyFont = DS.getFontFamily('body');
+    const displayFont = this.getFontFamily('display');
+    const bodyFont = this.getFontFamily('body');
 
     // Dark overlay background
     this.background = scene.add.rectangle(
       width / 2, height / 2, width, height,
-      DS.colorStringToNumber(palette.overlay), 0.8
+      this.colorToNumber(palette.overlay), 0.8
     );
     this.background.setInteractive();
     this.add(this.background);
@@ -70,9 +70,9 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.panel = scene.add.rectangle(
       width / 2, height / 2,
       panelWidth, panelHeight,
-      DS.colorStringToNumber(palette.panelBackground), 1
+      this.colorToNumber(palette.panelBackground), 1
     );
-    this.panel.setStrokeStyle(2, DS.colorStringToNumber(palette.panelBorder), 0.3);
+    this.panel.setStrokeStyle(2, this.colorToNumber(palette.panelBorder), 0.3);
     this.add(this.panel);
 
     // Title with gradient effect
@@ -80,7 +80,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
       width / 2, height / 2 - panelHeight / 2 + 40,
       'LEADERBOARD',
       {
-        fontSize: DS.getFontSize('2xl'),
+        fontSize: this.getFontSize('2xl'),
         fontFamily: displayFont,
         fontStyle: '900 normal',
         color: palette.textPrimary
@@ -125,7 +125,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     // Loading indicator
     this.loadingText = scene.add.text(0, 0, 'Loading...', {
-      fontSize: DS.getFontSize('lg'),
+      fontSize: this.getFontSize('lg'),
       fontFamily: bodyFont,
       color: palette.gray
     }).setOrigin(0.5).setVisible(false);
@@ -133,7 +133,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     // Empty state
     this.emptyText = scene.add.text(0, 0, 'No scores yet.\nBe the first!', {
-      fontSize: DS.getFontSize('lg'),
+      fontSize: this.getFontSize('lg'),
       fontFamily: bodyFont,
       color: palette.grayMuted,
       align: 'center'
@@ -144,9 +144,8 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.createPlayerPositionDisplay(scene, width / 2, height / 2 + panelHeight / 2 - 50, panelWidth);
 
     // Initialize
-    this.setDepth(DS.LAYERS.modal);
+    this.setDepth(this.layers.modal);
     this.setVisible(false);
-    scene.add.existing(this);
   }
 
   /**
@@ -156,26 +155,26 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.closeButton = scene.add.container(x, y);
 
     const palette = this.getPalette();
-    const bg = scene.add.circle(0, 0, 20, DS.colorStringToNumber(palette.closeBg), 1);
-    bg.setStrokeStyle(1, DS.colorStringToNumber(palette.panelBorder), 0.3);
+    const bg = scene.add.circle(0, 0, 20, this.colorToNumber(palette.closeBg), 1);
+    bg.setStrokeStyle(1, this.colorToNumber(palette.panelBorder), 0.3);
     bg.setInteractive();
 
     const closeX = scene.add.text(0, 0, '✕', {
-      fontSize: DS.getFontSize('lg'),
-      fontFamily: DS.getFontFamily('body'),
+      fontSize: this.getFontSize('lg'),
+      fontFamily: this.getFontFamily('body'),
       color: palette.closeText
     }).setOrigin(0.5);
 
     this.closeButton.add([bg, closeX]);
 
     bg.on('pointerover', () => {
-      bg.setFillStyle(DS.colorStringToNumber(palette.closeBgHover));
+      bg.setFillStyle(this.colorToNumber(palette.closeBgHover));
       closeX.setColor(palette.textPrimary);
       scene.input.setDefaultCursor('pointer');
     });
 
     bg.on('pointerout', () => {
-      bg.setFillStyle(DS.colorStringToNumber(palette.closeBg));
+      bg.setFillStyle(this.colorToNumber(palette.closeBg));
       closeX.setColor(palette.closeText);
       scene.input.setDefaultCursor('default');
     });
@@ -199,7 +198,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     this.tabIndicator = scene.add.rectangle(
       -tabWidth - 10, tabHeight / 2 + 5,
       tabWidth - 20, 3,
-      DS.colorStringToNumber(palette.highlight), 1
+      this.colorToNumber(palette.highlight), 1
     );
     this.tabContainer.add(this.tabIndicator);
 
@@ -234,13 +233,13 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
   ): Phaser.GameObjects.Container {
     const tab = scene.add.container(x, y);
     const palette = this.getPalette();
-    const displayFont = DS.getFontFamily('display');
+    const displayFont = this.getFontFamily('display');
 
     const bg = scene.add.rectangle(0, 0, width - 20, 35, 0x000000, 0);
     bg.setInteractive();
 
     const text = scene.add.text(0, 0, label, {
-      fontSize: DS.getFontSize('sm'),
+      fontSize: this.getFontSize('sm'),
       fontFamily: displayFont,
       fontStyle: '700 normal',
       color: type === this.activeTab ? palette.textPrimary : palette.grayMuted
@@ -323,12 +322,12 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
   ): Phaser.GameObjects.Container {
     const row = scene.add.container(0, y);
     const palette = this.getPalette();
-    const displayFont = DS.getFontFamily('display');
-    const bodyFont = DS.getFontFamily('body');
+    const displayFont = this.getFontFamily('display');
+    const bodyFont = this.getFontFamily('body');
 
     // Background for current user
     if (entry.isCurrentUser) {
-      const highlightColor = DS.colorStringToNumber(palette.highlight);
+      const highlightColor = this.colorToNumber(palette.highlight);
       const bg = scene.add.rectangle(0, 0, width - 40, 50, highlightColor, 0.1);
       bg.setStrokeStyle(1, highlightColor, 0.3);
       row.add(bg);
@@ -338,16 +337,16 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
     const rankBg = scene.add.circle(-width / 2 + 50, 0, 18, 0x000000, 0);
     if (entry.rank <= 3) {
       const colors = [palette.gold, palette.silver, palette.bronze];
-      const colorValue = DS.colorStringToNumber(colors[entry.rank - 1]);
+      const colorValue = this.colorToNumber(colors[entry.rank - 1]);
       rankBg.setFillStyle(colorValue, 0.2);
       rankBg.setStrokeStyle(2, colorValue, 0.8);
     } else {
-      rankBg.setStrokeStyle(1, DS.colorStringToNumber(palette.highlightBorder), 0.5);
+      rankBg.setStrokeStyle(1, this.colorToNumber(palette.highlightBorder), 0.5);
     }
     row.add(rankBg);
 
     const rankText = scene.add.text(-width / 2 + 50, 0, entry.rank.toString(), {
-      fontSize: entry.rank <= 3 ? DS.getFontSize('lg') : DS.getFontSize('base'),
+      fontSize: entry.rank <= 3 ? this.getFontSize('lg') : this.getFontSize('base'),
       fontFamily: displayFont,
       fontStyle: '700 normal',
       color: entry.rank <= 3
@@ -358,7 +357,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
     // Username
     const username = scene.add.text(-width / 2 + 100, 0, entry.username, {
-      fontSize: DS.getFontSize('base'),
+      fontSize: this.getFontSize('base'),
       fontFamily: bodyFont,
       fontStyle: entry.isCurrentUser ? '600 normal' : '400 normal',
       color: entry.isCurrentUser ? palette.textPrimary : palette.grayLighter
@@ -370,7 +369,7 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
       [palette.gold, palette.silver, palette.bronze][entry.rank - 1] : palette.gray;
 
     const score = scene.add.text(width / 2 - 50, 0, entry.score.toLocaleString(), {
-      fontSize: DS.getFontSize('lg'),
+      fontSize: this.getFontSize('lg'),
       fontFamily: displayFont,
       fontStyle: '600 normal',
       color: scoreColor
@@ -663,20 +662,20 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
   private createPlayerPositionDisplay(scene: Phaser.Scene, x: number, y: number, panelWidth: number): void {
     this.playerPositionContainer = scene.add.container(x, y);
     const palette = this.getPalette();
-    const displayFont = DS.getFontFamily('display');
+    const displayFont = this.getFontFamily('display');
 
     // Background bar
     this.playerPositionBg = scene.add.rectangle(
       0, 0,
       panelWidth - 40, 60,
-      DS.colorStringToNumber(palette.closeBg), 1
+      this.colorToNumber(palette.closeBg), 1
     );
-    this.playerPositionBg.setStrokeStyle(1, DS.colorStringToNumber(palette.panelBorder), 0.5);
+    this.playerPositionBg.setStrokeStyle(1, this.colorToNumber(palette.panelBorder), 0.5);
     this.playerPositionContainer.add(this.playerPositionBg);
 
     // Player rank text
     this.playerPositionText = scene.add.text(0, 0, 'Your Rank: Calculating...', {
-      fontSize: DS.getFontSize('lg'),
+      fontSize: this.getFontSize('lg'),
       fontFamily: displayFont,
       fontStyle: '600 normal',
       color: palette.textPrimary
@@ -690,11 +689,12 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
    * Update player position based on score
    */
   private async updatePlayerPosition(entries: LeaderboardEntry[]): Promise<void> {
+    const palette = this.getPalette();
+
     try {
       const { highScoreService } = await import('../../../services/HighScoreService');
       const currentUsername = highScoreService.getUsername();
       const currentScore = this.currentPlayerScore || 0;
-      const palette = this.getPalette();
 
       // Find player in entries
       const playerEntry = entries.find(e => e.username === currentUsername);
@@ -735,28 +735,28 @@ export class ModernLeaderboardUI extends Phaser.GameObjects.Container {
 
   private getPalette() {
     return {
-      overlay: DS.getColor('solid', 'bgPrimary'),
-      panelBackground: DS.getColor('accents', 'indigoSurface'),
-      panelBorder: DS.getColor('accents', 'indigo'),
-      textPrimary: DS.getColor('solid', 'textPrimary'),
-      textMuted: DS.getColor('accents', 'gray'),
-      textSubtle: DS.getColor('accents', 'grayMuted'),
-      textSecondary: DS.getColor('accents', 'grayLight'),
-      closeBg: DS.getColor('accents', 'indigoSurface'),
-      closeBgHover: DS.getColor('accents', 'indigoSurfaceHover'),
-      closeText: DS.getColor('accents', 'gray'),
-      highlight: DS.getColor('accents', 'indigo'),
-      highlightSurface: DS.getColor('accents', 'indigoSurface'),
-      highlightHover: DS.getColor('accents', 'indigoSurfaceHover'),
-      highlightBorder: DS.getColor('accents', 'indigoSurfaceBorder'),
-      gold: DS.getColor('accents', 'gold'),
-      silver: DS.getColor('accents', 'silver'),
-      bronze: DS.getColor('accents', 'bronze'),
-      gray: DS.getColor('accents', 'gray'),
-      grayLight: DS.getColor('accents', 'grayLight'),
-      grayLighter: DS.getColor('accents', 'grayLighter'),
-      grayMuted: DS.getColor('accents', 'grayMuted'),
-      blueSoft: DS.getColor('accents', 'blueSoft'),
+      overlay: this.getColor('solid', 'bgPrimary'),
+      panelBackground: this.getColor('accents', 'indigoSurface'),
+      panelBorder: this.getColor('accents', 'indigo'),
+      textPrimary: this.getColor('solid', 'textPrimary'),
+      textMuted: this.getColor('accents', 'gray'),
+      textSubtle: this.getColor('accents', 'grayMuted'),
+      textSecondary: this.getColor('accents', 'grayLight'),
+      closeBg: this.getColor('accents', 'indigoSurface'),
+      closeBgHover: this.getColor('accents', 'indigoSurfaceHover'),
+      closeText: this.getColor('accents', 'gray'),
+      highlight: this.getColor('accents', 'indigo'),
+      highlightSurface: this.getColor('accents', 'indigoSurface'),
+      highlightHover: this.getColor('accents', 'indigoSurfaceHover'),
+      highlightBorder: this.getColor('accents', 'indigoSurfaceBorder'),
+      gold: this.getColor('accents', 'gold'),
+      silver: this.getColor('accents', 'silver'),
+      bronze: this.getColor('accents', 'bronze'),
+      gray: this.getColor('accents', 'gray'),
+      grayLight: this.getColor('accents', 'grayLight'),
+      grayLighter: this.getColor('accents', 'grayLighter'),
+      grayMuted: this.getColor('accents', 'grayMuted'),
+      blueSoft: this.getColor('accents', 'blueSoft'),
     };
   }
 

--- a/src/client/game/presentation/ui/SettingsUI.ts
+++ b/src/client/game/presentation/ui/SettingsUI.ts
@@ -2,10 +2,10 @@
  * Settings UI component with username customization
  */
 import * as Phaser from 'phaser';
-import { DS } from '../../config/DesignSystem';
 import { highScoreService } from '../../../services/HighScoreService';
+import { UIComponent } from './components/UIComponent';
 
-export class SettingsUI extends Phaser.GameObjects.Container {
+export class SettingsUI extends UIComponent {
   private background: Phaser.GameObjects.Rectangle;
   private panel: Phaser.GameObjects.Rectangle;
   private titleText: Phaser.GameObjects.Text;
@@ -27,49 +27,40 @@ export class SettingsUI extends Phaser.GameObjects.Container {
   private pendingUsername: string = '';
 
   constructor(scene: Phaser.Scene) {
-    super(scene, 0, 0);
+    super(scene, { visible: false });
 
     const { width, height } = scene.cameras.main;
 
-    const spacing = {
-      xl: DS.getSpacingValue('xl'),
-      lg: DS.getSpacingValue('lg'),
-      md: DS.getSpacingValue('md'),
-      base: DS.getSpacingValue('sm'),
-    };
+    const spacing = this.spacing;
 
     const palette = {
-      overlay: DS.getColor('solid', 'bgPrimary'),
-      panelBackground: DS.getColor('accents', 'indigoSurface'),
-      panelBorder: DS.getColor('accents', 'indigo'),
-      title: DS.getColor('solid', 'textPrimary'),
-      closeBg: DS.getColor('accents', 'indigoSurface'),
-      closeBgHover: DS.getColor('accents', 'indigoSurfaceHover'),
-      closeText: DS.getColor('accents', 'gray'),
-      sectionLabel: DS.getColor('accents', 'gray'),
-      usernameCustom: DS.getColor('accents', 'indigo'),
-      usernameDefault: DS.getColor('accents', 'grayLight'),
-      redditLabel: DS.getColor('accents', 'grayMuted'),
-      inputBg: DS.getColor('accents', 'indigoSurface'),
-      inputBorder: DS.getColor('accents', 'indigo'),
-      buttonPrimary: DS.getColor('accents', 'indigo'),
-      buttonDanger: DS.getColor('accents', 'crimson'),
-      buttonSuccess: DS.getColor('accents', 'mint'),
-      statusDanger: DS.getColor('accents', 'crimson'),
-      statusSuccess: DS.getColor('accents', 'mint'),
-      statusWarning: DS.getColor('accents', 'amber'),
+      overlay: this.getColor('solid', 'bgPrimary'),
+      panelBackground: this.getColor('accents', 'indigoSurface'),
+      panelBorder: this.getColor('accents', 'indigo'),
+      title: this.getColor('solid', 'textPrimary'),
+      closeBg: this.getColor('accents', 'indigoSurface'),
+      closeBgHover: this.getColor('accents', 'indigoSurfaceHover'),
+      closeText: this.getColor('accents', 'gray'),
+      sectionLabel: this.getColor('accents', 'gray'),
+      usernameCustom: this.getColor('accents', 'indigo'),
+      usernameDefault: this.getColor('accents', 'grayLight'),
+      redditLabel: this.getColor('accents', 'grayMuted'),
+      inputBg: this.getColor('accents', 'indigoSurface'),
+      inputBorder: this.getColor('accents', 'indigo'),
+      buttonPrimary: this.getColor('accents', 'indigo'),
+      buttonDanger: this.getColor('accents', 'crimson'),
+      buttonSuccess: this.getColor('accents', 'mint'),
+      statusDanger: this.getColor('accents', 'crimson'),
+      statusSuccess: this.getColor('accents', 'mint'),
+      statusWarning: this.getColor('accents', 'amber'),
     };
 
-    const fonts = {
-      display: DS.getFontFamily('display'),
-      displayBlack: DS.getFontFamily('displayBlack'),
-      body: DS.getFontFamily('body'),
-    };
+    const fonts = this.typography.fontFamily;
 
     // Dark overlay background
     this.background = scene.add.rectangle(
       width / 2, height / 2, width, height,
-      DS.colorStringToNumber(palette.overlay), 0.8
+      this.colorToNumber(palette.overlay), 0.8
     );
     this.background.setInteractive();
     this.add(this.background);
@@ -81,17 +72,17 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.panel = scene.add.rectangle(
       width / 2, height / 2,
       panelWidth, panelHeight,
-      DS.colorStringToNumber(palette.panelBackground), 1
+      this.colorToNumber(palette.panelBackground), 1
     );
-    this.panel.setStrokeStyle(2, DS.colorStringToNumber(palette.panelBorder), 0.3);
+    this.panel.setStrokeStyle(2, this.colorToNumber(palette.panelBorder), 0.3);
     this.add(this.panel);
 
     // Title
     this.titleText = scene.add.text(
-      width / 2, height / 2 - panelHeight / 2 + spacing.xl + spacing.base,
+      width / 2, height / 2 - panelHeight / 2 + spacing.xl + spacing.sm,
       'SETTINGS',
       {
-        fontSize: DS.getFontSize('xl'),
+        fontSize: this.getFontSize('xl'),
         fontFamily: fonts.displayBlack,
         fontStyle: '900 normal',
         color: palette.title
@@ -112,7 +103,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 + 20,
       '🏆 LEADERBOARD',
-      DS.getColor('accents', 'indigo'),
+      this.getColor('accents', 'indigo'),
       () => {
         this.hide();
         this.emit('showLeaderboard');
@@ -126,7 +117,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       width / 2,
       height / 2 + 80,
       '🔄 RESET GAME',
-      DS.getColor('accents', 'crimson'),
+      this.getColor('accents', 'crimson'),
       () => {
         this.confirmReset(scene);
       }
@@ -134,9 +125,8 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.add(this.resetButton);
 
     // Initially hidden
-    this.setDepth(DS.LAYERS.modal);
+    this.setDepth(this.layers.modal);
     this.setVisible(false);
-    scene.add.existing(this);
   }
 
   /**
@@ -145,27 +135,27 @@ export class SettingsUI extends Phaser.GameObjects.Container {
   private createCloseButton(scene: Phaser.Scene, x: number, y: number): void {
     this.closeButton = scene.add.container(x, y);
 
-    const bg = scene.add.circle(0, 0, 20, DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')), 1);
-    bg.setStrokeStyle(1, DS.colorStringToNumber(DS.getColor('accents', 'indigo')), 0.3);
+    const bg = scene.add.circle(0, 0, 20, this.colorToNumber(this.getColor('accents', 'indigoSurface')), 1);
+    bg.setStrokeStyle(1, this.colorToNumber(this.getColor('accents', 'indigo')), 0.3);
     bg.setInteractive();
 
     const closeX = scene.add.text(0, 0, '✕', {
-      fontSize: DS.getFontSize('lg'),
-      fontFamily: DS.getFontFamily('body'),
-      color: DS.getColor('accents', 'gray')
+      fontSize: this.getFontSize('lg'),
+      fontFamily: this.getFontFamily('body'),
+      color: this.getColor('accents', 'gray')
     }).setOrigin(0.5);
 
     this.closeButton.add([bg, closeX]);
 
     bg.on('pointerover', () => {
-      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigoSurfaceHover')));
-      closeX.setColor(DS.getColor('solid', 'textPrimary'));
+      bg.setFillStyle(this.colorToNumber(this.getColor('accents', 'indigoSurfaceHover')));
+      closeX.setColor(this.getColor('solid', 'textPrimary'));
       scene.input.setDefaultCursor('pointer');
     });
 
     bg.on('pointerout', () => {
-      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')));
-      closeX.setColor(DS.getColor('accents', 'gray'));
+      bg.setFillStyle(this.colorToNumber(this.getColor('accents', 'indigoSurface')));
+      closeX.setColor(this.getColor('accents', 'gray'));
       scene.input.setDefaultCursor('default');
     });
 
@@ -180,10 +170,10 @@ export class SettingsUI extends Phaser.GameObjects.Container {
   private createUsernameSection(scene: Phaser.Scene, x: number, y: number, panelWidth: number): void {
     // Section title
     const sectionTitle = scene.add.text(x, y, 'USERNAME', {
-      fontSize: DS.getFontSize('sm'),
-      fontFamily: DS.getFontFamily('display'),
+      fontSize: this.getFontSize('sm'),
+      fontFamily: this.getFontFamily('display'),
       fontStyle: '600 normal',
-      color: DS.getColor('accents', 'gray')
+      color: this.getColor('accents', 'gray')
     }).setOrigin(0.5);
     this.add(sectionTitle);
 
@@ -192,19 +182,19 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const isCustom = highScoreService.hasCustomUsername();
 
     this.currentUsernameText = scene.add.text(x, y + 30, currentUsername, {
-      fontSize: DS.getFontSize('lg'),
-      fontFamily: DS.getFontFamily('display'),
+      fontSize: this.getFontSize('lg'),
+      fontFamily: this.getFontFamily('display'),
       fontStyle: '700 normal',
-      color: isCustom ? DS.getColor('accents', 'indigo') : DS.getColor('accents', 'grayLight')
+      color: isCustom ? this.getColor('accents', 'indigo') : this.getColor('accents', 'grayLight')
     }).setOrigin(0.5);
     this.add(this.currentUsernameText);
 
     // Reddit username indicator
     if (!isCustom) {
       const redditLabel = scene.add.text(x, y + 55, '(Reddit Username)', {
-        fontSize: DS.getFontSize('sm'),
-        fontFamily: DS.getFontFamily('body'),
-        color: DS.getColor('accents', 'grayMuted')
+        fontSize: this.getFontSize('sm'),
+        fontFamily: this.getFontFamily('body'),
+        color: this.getColor('accents', 'grayMuted')
       }).setOrigin(0.5);
       this.add(redditLabel);
     }
@@ -213,25 +203,25 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.usernameInputBg = scene.add.rectangle(
       x, y + 90,
       panelWidth - 80, 40,
-      DS.colorStringToNumber(DS.getColor('accents', 'indigoSurface')), 1
+      this.colorToNumber(this.getColor('accents', 'indigoSurface')), 1
     );
-    this.usernameInputBg.setStrokeStyle(2, DS.colorStringToNumber(DS.getColor('accents', 'indigo')), 0.5);
+    this.usernameInputBg.setStrokeStyle(2, this.colorToNumber(this.getColor('accents', 'indigo')), 0.5);
     this.usernameInputBg.setVisible(false);
     this.add(this.usernameInputBg);
 
     this.usernameInput = scene.add.text(x, y + 90, '', {
-      fontSize: DS.getFontSize('base'),
-      fontFamily: DS.getFontFamily('body'),
-      color: DS.getColor('solid', 'textPrimary')
+      fontSize: this.getFontSize('base'),
+      fontFamily: this.getFontFamily('body'),
+      color: this.getColor('solid', 'textPrimary')
     }).setOrigin(0.5);
     this.usernameInput.setVisible(false);
     this.add(this.usernameInput);
 
     // Status text
     this.usernameStatusText = scene.add.text(x, y + 130, '', {
-      fontSize: DS.getFontSize('sm'),
-      fontFamily: DS.getFontFamily('body'),
-      color: DS.getColor('accents', 'grayMuted')
+      fontSize: this.getFontSize('sm'),
+      fontFamily: this.getFontFamily('body'),
+      color: this.getColor('accents', 'grayMuted')
     }).setOrigin(0.5).setVisible(false);
     this.add(this.usernameStatusText);
 
@@ -239,7 +229,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     this.changeUsernameButton = this.createActionButton(
       scene, x, y + 90,
       isCustom ? 'CHANGE USERNAME' : 'SET CUSTOM USERNAME',
-      DS.getColor('accents', 'mint'),
+      this.getColor('accents', 'mint'),
       () => this.toggleUsernameEdit(scene)
     );
     this.add(this.changeUsernameButton);
@@ -261,16 +251,16 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const buttonWidth = 260;
     const buttonHeight = 45;
 
-    const fillColor = DS.colorStringToNumber(color);
+    const fillColor = this.colorToNumber(color);
     const bg = scene.add.rectangle(0, 0, buttonWidth, buttonHeight, fillColor, 0.9);
     bg.setStrokeStyle(1, fillColor, 0.3);
     bg.setInteractive();
 
     const label = scene.add.text(0, 0, text, {
-      fontSize: DS.getFontSize('base'),
-      fontFamily: DS.getFontFamily('display'),
+      fontSize: this.getFontSize('base'),
+      fontFamily: this.getFontFamily('display'),
       fontStyle: '600 normal',
-      color: DS.getColor('solid', 'textPrimary')
+      color: this.getColor('solid', 'textPrimary')
     }).setOrigin(0.5);
 
     button.add([bg, label]);
@@ -304,20 +294,20 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       this.usernameInputBg.setVisible(true);
       this.usernameInput.setVisible(true);
       this.usernameInput.setText('Enter new username...');
-      this.usernameInput.setColor(DS.getColor('accents', 'grayMuted'));
+      this.usernameInput.setColor(this.getColor('accents', 'grayMuted'));
 
       // Update button
       const bg = this.changeUsernameButton.getData('bg') as Phaser.GameObjects.Rectangle;
       const label = this.changeUsernameButton.getData('label') as Phaser.GameObjects.Text;
       label.setText('SAVE USERNAME');
-      bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'indigo')));
+      bg.setFillStyle(this.colorToNumber(this.getColor('accents', 'indigo')));
 
       // Setup keyboard input
       this.setupKeyboardInput(scene);
 
       // Show status
       this.usernameStatusText.setText('3-20 characters, letters/numbers/underscore only');
-      this.usernameStatusText.setColor(DS.getColor('accents', 'grayMuted'));
+      this.usernameStatusText.setColor(this.getColor('accents', 'grayMuted'));
       this.usernameStatusText.setVisible(true);
     } else {
       // Save username
@@ -359,10 +349,10 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       // Update display
       if (this.pendingUsername.length > 0) {
         this.usernameInput.setText(this.pendingUsername);
-        this.usernameInput.setColor(DS.getColor('solid', 'textPrimary'));
+        this.usernameInput.setColor(this.getColor('solid', 'textPrimary'));
       } else {
         this.usernameInput.setText('Enter new username...');
-        this.usernameInput.setColor(DS.getColor('accents', 'grayMuted'));
+        this.usernameInput.setColor(this.getColor('accents', 'grayMuted'));
       }
 
       // Validate
@@ -378,24 +368,24 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
     if (username.length < 3) {
       this.usernameStatusText.setText('Username too short (min 3 characters)');
-      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
+      this.usernameStatusText.setColor(this.getColor('accents', 'crimson'));
       return;
     }
 
     if (username.length > 20) {
       this.usernameStatusText.setText('Username too long (max 20 characters)');
-      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
+      this.usernameStatusText.setColor(this.getColor('accents', 'crimson'));
       return;
     }
 
     if (!/^[a-zA-Z0-9_]+$/.test(username)) {
       this.usernameStatusText.setText('Only letters, numbers, and underscore allowed');
-      this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
+      this.usernameStatusText.setColor(this.getColor('accents', 'crimson'));
       return;
     }
 
     this.usernameStatusText.setText('✓ Valid username');
-    this.usernameStatusText.setColor(DS.getColor('accents', 'mint'));
+    this.usernameStatusText.setColor(this.getColor('accents', 'mint'));
   }
 
   /**
@@ -412,7 +402,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
     // Check uniqueness
     this.usernameStatusText.setText('Checking availability...');
-    this.usernameStatusText.setColor(DS.getColor('accents', 'amber'));
+    this.usernameStatusText.setColor(this.getColor('accents', 'amber'));
 
     try {
       // Check if username is available
@@ -431,14 +421,14 @@ export class SettingsUI extends Phaser.GameObjects.Container {
 
           // Update display
           this.currentUsernameText.setText(username);
-          this.currentUsernameText.setColor(DS.getColor('accents', 'indigo'));
+          this.currentUsernameText.setColor(this.getColor('accents', 'indigo'));
 
           // Exit edit mode
           this.cancelUsernameEdit();
 
           // Show success
           this.usernameStatusText.setText('✓ Username saved!');
-          this.usernameStatusText.setColor(DS.getColor('accents', 'mint'));
+          this.usernameStatusText.setColor(this.getColor('accents', 'mint'));
           this.usernameStatusText.setVisible(true);
 
           // Hide status after 2 seconds
@@ -447,7 +437,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
           });
         } else {
           this.usernameStatusText.setText('Username already taken');
-          this.usernameStatusText.setColor(DS.getColor('accents', 'crimson'));
+          this.usernameStatusText.setColor(this.getColor('accents', 'crimson'));
         }
       } else {
         throw new Error('Failed to check username');
@@ -457,11 +447,11 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       // Allow setting username offline
       highScoreService.setCustomUsername(username);
       this.currentUsernameText.setText(username);
-      this.currentUsernameText.setColor(DS.getColor('accents', 'indigo'));
+      this.currentUsernameText.setColor(this.getColor('accents', 'indigo'));
       this.cancelUsernameEdit();
 
       this.usernameStatusText.setText('✓ Username saved locally');
-      this.usernameStatusText.setColor(DS.getColor('accents', 'amber'));
+      this.usernameStatusText.setColor(this.getColor('accents', 'amber'));
       this.usernameStatusText.setVisible(true);
 
       this.scene.time.delayedCall(2000, () => {
@@ -484,7 +474,7 @@ export class SettingsUI extends Phaser.GameObjects.Container {
     const bg = this.changeUsernameButton.getData('bg') as Phaser.GameObjects.Rectangle;
     const label = this.changeUsernameButton.getData('label') as Phaser.GameObjects.Text;
     label.setText(highScoreService.hasCustomUsername() ? 'CHANGE USERNAME' : 'SET CUSTOM USERNAME');
-    bg.setFillStyle(DS.colorStringToNumber(DS.getColor('accents', 'mint')));
+    bg.setFillStyle(this.colorToNumber(this.getColor('accents', 'mint')));
 
     // Clear keyboard listeners
     this.scene.input.keyboard?.removeAllListeners();
@@ -499,9 +489,9 @@ export class SettingsUI extends Phaser.GameObjects.Container {
       scene.cameras.main.height / 2 + 140,
       'Are you sure? This will reset your progress!',
       {
-        fontSize: DS.getFontSize('sm'),
-        fontFamily: DS.getFontFamily('body'),
-        color: DS.getColor('accents', 'crimson')
+        fontSize: this.getFontSize('sm'),
+        fontFamily: this.getFontFamily('body'),
+        color: this.getColor('accents', 'crimson')
       }
     ).setOrigin(0.5);
     this.add(confirmText);

--- a/src/client/game/presentation/ui/components/UIComponent.ts
+++ b/src/client/game/presentation/ui/components/UIComponent.ts
@@ -1,0 +1,125 @@
+import * as Phaser from 'phaser';
+import { DS } from '../../../config/DesignSystem';
+
+type SpacingToken = keyof typeof DS.SPACING;
+type FontFamilyToken = keyof typeof DS.TYPOGRAPHY.fontFamily;
+type FontSizeToken = keyof typeof DS.TYPOGRAPHY.fontSize;
+type FontWeightToken = keyof typeof DS.TYPOGRAPHY.fontWeight;
+type TextVariant = 'display' | 'heading' | 'body' | 'caption' | 'button';
+
+export interface UIComponentOptions {
+  x?: number;
+  y?: number;
+  depth?: number;
+  visible?: boolean;
+}
+
+type TypographyTokens = {
+  fontFamily: Record<FontFamilyToken, string>;
+  fontSize: Record<FontSizeToken, string>;
+  fontWeight: Record<FontWeightToken, string>;
+};
+
+export abstract class UIComponent extends Phaser.GameObjects.Container {
+  public readonly spacing: Readonly<Record<SpacingToken, number>>;
+  public readonly typography: Readonly<TypographyTokens>;
+  public readonly layers = DS.LAYERS;
+  public readonly animation = DS.ANIMATION;
+  public readonly radius = DS.RADIUS;
+
+  constructor(scene: Phaser.Scene, options: UIComponentOptions = {}) {
+    const { x = 0, y = 0, depth, visible = true } = options;
+    super(scene, x, y);
+
+    this.spacing = UIComponent.buildSpacing();
+    this.typography = UIComponent.buildTypography();
+
+    if (depth !== undefined) {
+      this.setDepth(depth);
+    }
+
+    this.setVisible(visible);
+
+    scene.add.existing(this);
+  }
+
+  public getSpacing(token: SpacingToken): number {
+    return this.spacing[token];
+  }
+
+  public getFontFamily(token: FontFamilyToken): string {
+    return this.typography.fontFamily[token];
+  }
+
+  public getFontSize(token: FontSizeToken): string {
+    return this.typography.fontSize[token];
+  }
+
+  public getFontWeight(token: FontWeightToken): string {
+    return this.typography.fontWeight[token];
+  }
+
+  public getTextStyle(
+    variant: TextVariant = 'body',
+    options?: {
+      color?: string;
+      weight?: FontWeightToken;
+      align?: 'left' | 'center' | 'right';
+    }
+  ): Phaser.Types.GameObjects.Text.TextStyle {
+    return DS.getTextStyle(variant, options);
+  }
+
+  public getColor(category: 'solid' | 'glass' | 'accents', key: string): string {
+    return DS.getColor(category, key);
+  }
+
+  public colorToNumber(color: string, fallback?: string): number {
+    return DS.colorStringToNumber(color, fallback);
+  }
+
+  public getGradient(name: keyof typeof DS.COLORS.gradients): string[] {
+    return DS.getGradient(name);
+  }
+
+  protected destroyChildren(): void {
+    this.removeAll(true);
+  }
+
+  private static buildSpacing(): Readonly<Record<SpacingToken, number>> {
+    const keys = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl'] as const;
+    const values = keys.reduce((acc, key) => {
+      acc[key] = DS.getSpacingValue(key);
+      return acc;
+    }, {} as Record<SpacingToken, number>);
+
+    return Object.freeze(values);
+  }
+
+  private static buildTypography(): Readonly<TypographyTokens> {
+    const fontFamilyKeys = ['display', 'displayBlack', 'body', 'mono'] as const;
+    const fontSizeKeys = ['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
+    const fontWeightKeys = ['light', 'regular', 'medium', 'semibold', 'bold', 'black'] as const;
+
+    const fontFamily = fontFamilyKeys.reduce((acc, key) => {
+      acc[key] = DS.getFontFamily(key);
+      return acc;
+    }, {} as Record<FontFamilyToken, string>);
+
+    const fontSize = fontSizeKeys.reduce((acc, key) => {
+      acc[key] = DS.getFontSize(key);
+      return acc;
+    }, {} as Record<FontSizeToken, string>);
+
+    const fontWeight = fontWeightKeys.reduce((acc, key) => {
+      acc[key] = DS.getFontWeight(key);
+      return acc;
+    }, {} as Record<FontWeightToken, string>);
+
+    return Object.freeze({
+      fontFamily: Object.freeze(fontFamily),
+      fontSize: Object.freeze(fontSize),
+      fontWeight: Object.freeze(fontWeight),
+    });
+  }
+}

--- a/test/uiComponent.test.ts
+++ b/test/uiComponent.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('phaser', () => {
+  class MockContainer {
+    public scene: any;
+    public x: number;
+    public y: number;
+    public depth = 0;
+    public visible = true;
+    public alpha = 1;
+    public scale = 1;
+    private children: any[] = [];
+
+    constructor(scene: any, x = 0, y = 0) {
+      this.scene = scene;
+      this.x = x;
+      this.y = y;
+    }
+
+    setDepth(value: number): this {
+      this.depth = value;
+      return this;
+    }
+
+    setVisible(value: boolean): this {
+      this.visible = value;
+      return this;
+    }
+
+    setAlpha(value: number): this {
+      this.alpha = value;
+      return this;
+    }
+
+    setScale(value: number): this {
+      this.scale = value;
+      return this;
+    }
+
+    setPosition(x: number, y: number): this {
+      this.x = x;
+      this.y = y;
+      return this;
+    }
+
+    add(child: any | any[]): this {
+      if (Array.isArray(child)) {
+        this.children.push(...child);
+      } else {
+        this.children.push(child);
+      }
+      return this;
+    }
+
+    removeAll(removeChildren?: boolean): this {
+      if (removeChildren) {
+        this.children.forEach(item => item?.destroy?.());
+      }
+      this.children = [];
+      return this;
+    }
+  }
+
+  class MockScene {
+    public add = {
+      existing: () => {},
+    };
+
+    public tweens = {
+      add: () => ({}),
+      killTweensOf: () => {},
+    };
+
+    public time = {
+      delayedCall: () => ({ remove: () => {} }),
+    };
+
+    public input = {
+      setDefaultCursor: () => {},
+      keyboard: {
+        removeAllListeners: () => {},
+        on: () => {},
+      },
+      on: () => {},
+    };
+
+    public cameras = {
+      main: { width: 800, height: 600 },
+    };
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      GameObjects: { Container: MockContainer },
+      Scene: MockScene,
+      Types: { GameObjects: { Text: {} } },
+    },
+    GameObjects: { Container: MockContainer },
+    Scene: MockScene,
+    Types: { GameObjects: { Text: {} } },
+  };
+});
+
+vi.mock('../src/client/services/HighScoreService', () => ({
+  highScoreService: {
+    getUsername: () => 'tester',
+    hasCustomUsername: () => false,
+    getRedditUsername: () => 'tester',
+    setCustomUsername: () => {},
+    submitScore: async () => ({ rank: undefined }),
+    getDailyLeaderboard: async () => [],
+    getHighScore: async () => 0,
+  },
+}));
+
+import * as Phaser from 'phaser';
+import { DS } from '../src/client/game/config/DesignSystem';
+import { UIComponent } from '../src/client/game/presentation/ui/components/UIComponent';
+import { GameOverUI } from '../src/client/game/presentation/ui/GameOverUI';
+import { SettingsUI } from '../src/client/game/presentation/ui/SettingsUI';
+import { ModernLeaderboardUI } from '../src/client/game/presentation/ui/ModernLeaderboardUI';
+import { ToastUI } from '../src/client/game/presentation/ui/ToastUI';
+
+class TestComponent extends UIComponent {
+  constructor(scene: Phaser.Scene) {
+    super(scene);
+  }
+}
+
+const createScene = (): Phaser.Scene => new Phaser.Scene();
+
+describe('UIComponent design tokens', () => {
+  it('exposes spacing values from the design system', () => {
+    const component = new TestComponent(createScene());
+    expect(component.getSpacing('lg')).toBe(DS.getSpacingValue('lg'));
+    expect(component.spacing.xl).toBe(DS.getSpacingValue('xl'));
+  });
+
+  it('exposes typography defaults from the design system', () => {
+    const component = new TestComponent(createScene());
+    expect(component.getFontFamily('display')).toBe(DS.getFontFamily('display'));
+    expect(component.typography.fontSize['2xl']).toBe(DS.getFontSize('2xl'));
+  });
+});
+
+describe.each([
+  ['GameOverUI', GameOverUI],
+  ['SettingsUI', SettingsUI],
+  ['ModernLeaderboardUI', ModernLeaderboardUI],
+  ['ToastUI', ToastUI],
+])('%s inheritance', (_, Component) => {
+  it('extends UIComponent', () => {
+    expect(Component.prototype instanceof UIComponent).toBe(true);
+  });
+
+  it('shares spacing and typography helpers', () => {
+    expect(Component.prototype.getSpacing).toBe(UIComponent.prototype.getSpacing);
+    expect(Component.prototype.getFontFamily).toBe(UIComponent.prototype.getFontFamily);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a reusable `UIComponent` base class that centralizes spacing, typography, and color access
- refactor `GameOverUI`, `SettingsUI`, `ModernLeaderboardUI`, and `ToastUI` to extend the new base component and remove duplicated design system lookups
- rewrite `ToastUI` to manage its own container via the base class and handle cleanup of tweens and timers
- add unit tests with mocked Phaser primitives to confirm spacing and typography defaults are inherited by UI components

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c96657b33c83278d981d6539d40c88