### PR TITLE
Make Phaser game responsive to viewport

### DIFF
--- a/src/client/game/main.ts
+++ b/src/client/game/main.ts
@@ -1,28 +1,74 @@
 import * as Phaser from 'phaser';
 import { MainScene } from './scenes/MainScene';
+import {
+  calculateResponsiveDimensions as computeResponsiveDimensions,
+  FALLBACK_VIEWPORT_HEIGHT,
+  FALLBACK_VIEWPORT_WIDTH,
+  MAX_GAME_HEIGHT,
+  MAX_GAME_WIDTH,
+  MIN_GAME_HEIGHT,
+  MIN_GAME_WIDTH,
+  ResponsiveDimensions
+} from './responsive';
 
 /**
  * Hexomind Game Configuration
  * Optimized for Reddit Devvit with high-DPI support
  */
 
-// Calculate optimal dimensions with DPR consideration
-const dpr = Math.max(window.devicePixelRatio || 1, 2); // Minimum 2x for sharpness
-const baseWidth = 800;
-const baseHeight = 900;
+const getDevicePixelRatio = (): number => {
+  if (typeof window === 'undefined') {
+    return 2;
+  }
 
-const config: Phaser.Types.Core.GameConfig = {
+  return Math.max(window.devicePixelRatio || 1, 2);
+};
+
+const getViewportSize = (parent?: string): { width: number; height: number } => {
+  if (typeof window === 'undefined') {
+    return { width: FALLBACK_VIEWPORT_WIDTH, height: FALLBACK_VIEWPORT_HEIGHT };
+  }
+
+  if (typeof document !== 'undefined' && parent) {
+    const element = document.getElementById(parent) ?? document.querySelector<HTMLElement>(`#${parent}`);
+    if (element) {
+      const rect = element.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        return { width: rect.width, height: rect.height };
+      }
+    }
+  }
+
+  const viewport = window.visualViewport;
+  if (viewport) {
+    return { width: viewport.width, height: viewport.height };
+  }
+
+  return {
+    width: window.innerWidth || FALLBACK_VIEWPORT_WIDTH,
+    height: window.innerHeight || FALLBACK_VIEWPORT_HEIGHT
+  };
+};
+
+const buildGameConfig = (
+  parent: string,
+  dimensions: ResponsiveDimensions,
+  resolution: number
+): Phaser.Types.Core.GameConfig => ({
   type: Phaser.WEBGL, // Force WebGL for better performance
-  parent: 'game-container',
+  parent,
   backgroundColor: '#1a1a1b', // Reddit dark mode default
-  // Enhanced resolution - use at least 2x for sharp rendering
-  resolution: dpr,
+  resolution,
   scale: {
     mode: Phaser.Scale.FIT, // Fit to container while maintaining aspect ratio
     autoCenter: Phaser.Scale.CENTER_BOTH,
-    width: baseWidth,
-    height: baseHeight,
-    parent: 'game-container'
+    width: dimensions.width,
+    height: dimensions.height,
+    parent,
+    minWidth: MIN_GAME_WIDTH,
+    minHeight: MIN_GAME_HEIGHT,
+    maxWidth: MAX_GAME_WIDTH,
+    maxHeight: MAX_GAME_HEIGHT
   },
   scene: [MainScene],
   physics: {
@@ -52,10 +98,38 @@ const config: Phaser.Types.Core.GameConfig = {
     autoMobilePipeline: false,
     multiTexture: true
   }
-};
+});
 
 const StartGame = (parent: string) => {
-  return new Phaser.Game({ ...config, parent });
+  const viewport = getViewportSize(parent);
+  const dimensions = computeResponsiveDimensions(viewport.width, viewport.height);
+  const config = buildGameConfig(parent, dimensions, getDevicePixelRatio());
+
+  const game = new Phaser.Game(config);
+
+  if (typeof window !== 'undefined') {
+    const updateSize = () => {
+      const { width: vpWidth, height: vpHeight } = getViewportSize(parent);
+      const nextDimensions = computeResponsiveDimensions(vpWidth, vpHeight);
+      game.scale.resize(nextDimensions.width, nextDimensions.height);
+      game.scale.refresh();
+    };
+
+    window.addEventListener('resize', updateSize);
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener('resize', updateSize);
+
+    game.scale.on(Phaser.Scale.Events.ORIENTATION_CHANGE, updateSize);
+
+    game.events.once(Phaser.Core.Events.DESTROY, () => {
+      window.removeEventListener('resize', updateSize);
+      visualViewport?.removeEventListener('resize', updateSize);
+      game.scale.off(Phaser.Scale.Events.ORIENTATION_CHANGE, updateSize);
+    });
+  }
+
+  return game;
 };
 
 export default StartGame;
+export { computeResponsiveDimensions as calculateResponsiveDimensions };

--- a/src/client/game/responsive.ts
+++ b/src/client/game/responsive.ts
@@ -1,0 +1,74 @@
+import { DesignSystem } from './config/DesignSystem';
+
+export const GAME_ASPECT_RATIO = 900 / 800;
+export const MIN_GAME_WIDTH = DesignSystem.BREAKPOINTS.xs;
+export const MAX_GAME_WIDTH = DesignSystem.BREAKPOINTS.xxl;
+export const MIN_GAME_HEIGHT = Math.round(MIN_GAME_WIDTH * GAME_ASPECT_RATIO);
+export const MAX_GAME_HEIGHT = Math.round(MAX_GAME_WIDTH * GAME_ASPECT_RATIO);
+export const FALLBACK_VIEWPORT_WIDTH = DesignSystem.BREAKPOINTS.md;
+export const FALLBACK_VIEWPORT_HEIGHT = Math.round(FALLBACK_VIEWPORT_WIDTH * GAME_ASPECT_RATIO);
+
+export type BreakpointKey = keyof typeof DesignSystem.BREAKPOINTS;
+export type Orientation = 'portrait' | 'landscape';
+
+export interface ResponsiveDimensions {
+  width: number;
+  height: number;
+  breakpoint: BreakpointKey;
+  orientation: Orientation;
+}
+
+const BREAKPOINT_ENTRIES = (Object.entries(DesignSystem.BREAKPOINTS) as [BreakpointKey, number][])
+  .sort((a, b) => a[1] - b[1]);
+
+const resolveBreakpoint = (width: number): BreakpointKey => {
+  let active = BREAKPOINT_ENTRIES[0][0];
+  for (const [key, value] of BREAKPOINT_ENTRIES) {
+    if (width >= value) {
+      active = key;
+    } else {
+      break;
+    }
+  }
+  return active;
+};
+
+export const calculateResponsiveDimensions = (
+  viewportWidth: number,
+  viewportHeight: number
+): ResponsiveDimensions => {
+  const safeWidth = Math.max(1, viewportWidth);
+  const safeHeight = Math.max(1, viewportHeight);
+  const orientation: Orientation = safeWidth >= safeHeight ? 'landscape' : 'portrait';
+
+  let width = Math.min(safeWidth, MAX_GAME_WIDTH);
+  if (orientation === 'landscape') {
+    width = Math.min(width, safeHeight / GAME_ASPECT_RATIO);
+  }
+
+  width = Math.min(width, safeWidth);
+  const preferredMinimum = Math.min(safeWidth, MIN_GAME_WIDTH);
+  width = Math.max(width, preferredMinimum);
+
+  let height = width * GAME_ASPECT_RATIO;
+
+  if (height > safeHeight) {
+    height = safeHeight;
+    width = Math.min(safeWidth, height / GAME_ASPECT_RATIO);
+  }
+
+  width = Math.min(width, safeWidth);
+  height = Math.min(height, safeHeight);
+
+  const roundedWidth = Math.max(1, Math.round(width));
+  const roundedHeight = Math.max(1, Math.round(height));
+
+  const breakpoint = resolveBreakpoint(Math.max(roundedWidth, Math.round(preferredMinimum)));
+
+  return {
+    width: roundedWidth,
+    height: roundedHeight,
+    breakpoint,
+    orientation
+  };
+};

--- a/test/responsiveGameDimensions.test.ts
+++ b/test/responsiveGameDimensions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { calculateResponsiveDimensions } from '../src/client/game/responsive';
+import { DesignSystem } from '../src/client/game/config/DesignSystem';
+
+const ASPECT_RATIO = 900 / 800;
+
+describe('calculateResponsiveDimensions', () => {
+  it('adapts to narrow portrait viewports and reports xs breakpoint', () => {
+    const result = calculateResponsiveDimensions(360, 780);
+
+    expect(result.orientation).toBe('portrait');
+    expect(result.breakpoint).toBe('xs');
+    expect(result.width).toBe(360);
+    expect(result.height).toBe(Math.round(360 * ASPECT_RATIO));
+  });
+
+  it('clamps width to the xxl breakpoint for extremely wide layouts', () => {
+    const result = calculateResponsiveDimensions(2200, 2800);
+
+    expect(result.breakpoint).toBe('xxl');
+    expect(result.width).toBe(DesignSystem.BREAKPOINTS.xxl);
+    expect(result.height).toBe(Math.round(DesignSystem.BREAKPOINTS.xxl * ASPECT_RATIO));
+  });
+
+  it('maintains aspect ratio when height is the constraining dimension', () => {
+    const result = calculateResponsiveDimensions(1920, 1080);
+
+    expect(result.orientation).toBe('landscape');
+    expect(result.height).toBe(1080);
+    expect(result.width).toBe(Math.round(1080 / ASPECT_RATIO));
+  });
+
+  it('selects the expected breakpoint for medium sized tablets', () => {
+    const result = calculateResponsiveDimensions(1024, 1280);
+
+    expect(result.width).toBe(1024);
+    expect(result.breakpoint).toBe('lg');
+  });
+});


### PR DESCRIPTION
## Summary
- derive the Phaser game configuration from viewport measurements and refresh it through the scale manager on resize/orientation changes
- add a shared responsive helper that maps DesignSystem breakpoints to dynamic width and height targets
- introduce unit tests that exercise the responsive dimension calculations for multiple viewport sizes

## Testing
- npm test
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c9a6dbc7908327ad74aee44cc3950b