### PR TITLE
Use supported Redis cardinality helper

### DIFF
--- a/src/server/api/dummyData.ts
+++ b/src/server/api/dummyData.ts
@@ -175,7 +175,7 @@ export async function initializeLeaderboards(): Promise<void> {
     console.log('Initializing leaderboards with dummy data...');
 
     // Check if we already have data
-    const globalCount = await redis.zcard('leaderboard:global');
+    const globalCount = await redis.zCard('leaderboard:global');
 
     if (globalCount < 50) {
       // Populate with different amounts for variety
@@ -189,7 +189,7 @@ export async function initializeLeaderboards(): Promise<void> {
 
       // Still populate daily and weekly if needed
       const today = new Date().toISOString().split('T')[0];
-      const dailyCount = await redis.zcard(`leaderboard:daily:${today}`);
+      const dailyCount = await redis.zCard(`leaderboard:daily:${today}`);
 
       if (dailyCount < 10) {
         await populateDailyLeaderboard(Math.floor(Math.random() * 10) + 10);
@@ -202,7 +202,7 @@ export async function initializeLeaderboards(): Promise<void> {
       const oneWeek = 1000 * 60 * 60 * 24 * 7;
       const week = Math.floor(diff / oneWeek) + 1;
       const year = now.getFullYear();
-      const weeklyCount = await redis.zcard(`leaderboard:weekly:${year}:${week}`);
+      const weeklyCount = await redis.zCard(`leaderboard:weekly:${year}:${week}`);
 
       if (weeklyCount < 25) {
         await populateWeeklyLeaderboard(Math.floor(Math.random() * 25) + 25);

--- a/src/server/api/highscores.ts
+++ b/src/server/api/highscores.ts
@@ -341,7 +341,7 @@ export async function getGameStatistics(): Promise<{
   topScore: number;
 }> {
   try {
-    const totalPlayers = await redis.zcard('leaderboard:global') || 0;
+    const totalPlayers = await redis.zCard('leaderboard:global') || 0;
     const totalGamesKey = 'stats:total_games';
     const totalGames = parseInt(await redis.get(totalGamesKey) || '0');
 

--- a/test/highscoreEndpoint.test.ts
+++ b/test/highscoreEndpoint.test.ts
@@ -69,7 +69,7 @@ vi.mock('@devvit/web/server', () => {
       expiryStore.set(key, seconds);
       return 1;
     },
-    async zcard(key: string): Promise<number> {
+    async zCard(key: string): Promise<number> {
       return sortedSets.get(key)?.size ?? 0;
     },
     async zrevrank(key: string, member: string): Promise<number | null> {


### PR DESCRIPTION
## Summary
- switch leaderboard initialization to use the supported Redis zCard helper
- update game statistics lookups and Redis mock to match the new helper name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca63354f7c8327b276b406b8c8c067