### PR TITLE
Use camelCase Redis helpers in leaderboard code

### DIFF
--- a/src/server/api/dummyData.ts
+++ b/src/server/api/dummyData.ts
@@ -66,11 +66,11 @@ export async function populateAllTimeLeaderboard(count: number = 100): Promise<v
       const score = generateScore(i, 50000);
 
       // Add to global leaderboard
-      await redis.zadd(leaderboardKey, { score, member: username });
+      await redis.zAdd(leaderboardKey, { score, member: username });
 
       // Add metadata
       const metaKey = `highscore:meta:${username}`;
-      await redis.hset(metaKey, {
+      await redis.hSet(metaKey, {
         score: score.toString(),
         timestamp: (Date.now() - Math.floor(Math.random() * 30 * 24 * 60 * 60 * 1000)).toString(), // Random time in last 30 days
         postId: 'dummy',
@@ -112,7 +112,7 @@ export async function populateDailyLeaderboard(count: number = 15): Promise<void
       const score = generateScore(i, 30000);
 
       // Add to daily leaderboard
-      await redis.zadd(leaderboardKey, { score, member: username });
+      await redis.zAdd(leaderboardKey, { score, member: username });
     }
 
     // Set expiry for daily leaderboard (7 days)
@@ -155,7 +155,7 @@ export async function populateWeeklyLeaderboard(count: number = 35): Promise<voi
       const score = generateScore(i, 40000);
 
       // Add to weekly leaderboard
-      await redis.zadd(leaderboardKey, { score, member: username });
+      await redis.zAdd(leaderboardKey, { score, member: username });
     }
 
     // Set expiry for weekly leaderboard (30 days)
@@ -175,7 +175,7 @@ export async function initializeLeaderboards(): Promise<void> {
     console.log('Initializing leaderboards with dummy data...');
 
     // Check if we already have data
-    const globalCount = await redis.zcard('leaderboard:global');
+    const globalCount = await redis.zCard('leaderboard:global');
 
     if (globalCount < 50) {
       // Populate with different amounts for variety
@@ -189,7 +189,7 @@ export async function initializeLeaderboards(): Promise<void> {
 
       // Still populate daily and weekly if needed
       const today = new Date().toISOString().split('T')[0];
-      const dailyCount = await redis.zcard(`leaderboard:daily:${today}`);
+      const dailyCount = await redis.zCard(`leaderboard:daily:${today}`);
 
       if (dailyCount < 10) {
         await populateDailyLeaderboard(Math.floor(Math.random() * 10) + 10);
@@ -202,7 +202,7 @@ export async function initializeLeaderboards(): Promise<void> {
       const oneWeek = 1000 * 60 * 60 * 24 * 7;
       const week = Math.floor(diff / oneWeek) + 1;
       const year = now.getFullYear();
-      const weeklyCount = await redis.zcard(`leaderboard:weekly:${year}:${week}`);
+      const weeklyCount = await redis.zCard(`leaderboard:weekly:${year}:${week}`);
 
       if (weeklyCount < 25) {
         await populateWeeklyLeaderboard(Math.floor(Math.random() * 25) + 25);
@@ -227,7 +227,7 @@ export async function ensurePlayerInLeaderboard(username: string, score: number)
           : null;
 
       if (parsedScore === null || Number.isNaN(parsedScore) || score > parsedScore) {
-        await redis.zadd(key, { score, member: username });
+        await redis.zAdd(key, { score, member: username });
       }
 
       if (expirySeconds) {

--- a/src/server/api/highscores.ts
+++ b/src/server/api/highscores.ts
@@ -40,11 +40,11 @@ export async function setUserHighScore(username: string, score: number): Promise
       await redis.set(key, score.toString());
 
       // Also update the leaderboard
-      await redis.zadd('leaderboard:global', { score, member: username });
+      await redis.zAdd('leaderboard:global', { score, member: username });
 
       // Store metadata
       const metaKey = `highscore:meta:${username}`;
-      await redis.hset(metaKey, {
+      await redis.hSet(metaKey, {
         score: score.toString(),
         timestamp: Date.now().toString(),
         postId: context.postId || '',
@@ -67,7 +67,7 @@ export async function setUserHighScore(username: string, score: number): Promise
 export async function getDailyLeaderboard(date: string, limit: number = 10): Promise<LeaderboardEntry[]> {
   try {
     const key = `leaderboard:daily:${date}`;
-    const scores = await redis.zrange(key, 0, limit - 1, {
+    const scores = await redis.zRange(key, 0, limit - 1, {
       reverse: true,
       withScores: true
     });
@@ -116,7 +116,7 @@ export async function updateDailyLeaderboard(username: string, score: number): P
         : null;
 
     if (parsedScore === null || Number.isNaN(parsedScore) || score > parsedScore) {
-      await redis.zadd(key, { score, member: username });
+      await redis.zAdd(key, { score, member: username });
     }
 
     // Set expiry for daily leaderboard (7 days)
@@ -145,7 +145,7 @@ export async function getWeeklyLeaderboard(limit: number = 10): Promise<Leaderbo
   try {
     const { week, year } = getWeekInfo();
     const key = `leaderboard:weekly:${year}:${week}`;
-    const scores = await redis.zrange(key, 0, limit - 1, {
+    const scores = await redis.zRange(key, 0, limit - 1, {
       reverse: true,
       withScores: true
     });
@@ -194,7 +194,7 @@ export async function updateWeeklyLeaderboard(username: string, score: number): 
         : null;
 
     if (parsedScore === null || Number.isNaN(parsedScore) || score > parsedScore) {
-      await redis.zadd(key, { score, member: username });
+      await redis.zAdd(key, { score, member: username });
     }
 
     // Set expiry for weekly leaderboard (30 days)
@@ -212,7 +212,7 @@ export async function getGlobalLeaderboard(limit: number = 10): Promise<Leaderbo
     console.log(`Getting global leaderboard, limit: ${limit}`);
 
     // Get top scores from sorted set
-    const scores = await redis.zrange('leaderboard:global', 0, limit - 1, {
+    const scores = await redis.zRange('leaderboard:global', 0, limit - 1, {
       reverse: true,
       withScores: true
     });
@@ -234,7 +234,7 @@ export async function getGlobalLeaderboard(limit: number = 10): Promise<Leaderbo
 
       // Get metadata
       const metaKey = `highscore:meta:${username}`;
-      const metadata = await redis.hgetall(metaKey);
+      const metadata = await redis.hGetAll(metaKey);
 
       entries.push({
         rank,
@@ -260,7 +260,7 @@ export async function getGlobalLeaderboard(limit: number = 10): Promise<Leaderbo
 export async function getSubredditLeaderboard(subreddit: string, limit: number = 10): Promise<LeaderboardEntry[]> {
   try {
     const key = `leaderboard:subreddit:${subreddit}`;
-    const scores = await redis.zrange(key, 0, limit - 1, {
+    const scores = await redis.zRange(key, 0, limit - 1, {
       reverse: true,
       withScores: true
     });
@@ -277,7 +277,7 @@ export async function getSubredditLeaderboard(subreddit: string, limit: number =
       const score = parseInt(scores[i + 1] as string);
 
       const metaKey = `highscore:meta:${username}:${subreddit}`;
-      const metadata = await redis.hgetall(metaKey);
+      const metadata = await redis.hGetAll(metaKey);
 
       entries.push({
         rank,
@@ -303,11 +303,11 @@ export async function getSubredditLeaderboard(subreddit: string, limit: number =
 export async function updateSubredditLeaderboard(username: string, score: number, subreddit: string): Promise<void> {
   try {
     const key = `leaderboard:subreddit:${subreddit}`;
-    await redis.zadd(key, { score, member: username });
+    await redis.zAdd(key, { score, member: username });
 
     // Store subreddit-specific metadata
     const metaKey = `highscore:meta:${username}:${subreddit}`;
-    await redis.hset(metaKey, {
+    await redis.hSet(metaKey, {
       score: score.toString(),
       timestamp: Date.now().toString(),
       postId: context.postId || '',
@@ -323,7 +323,7 @@ export async function updateSubredditLeaderboard(username: string, score: number
  */
 export async function getUserRank(username: string): Promise<number | null> {
   try {
-    const rank = await redis.zrevrank('leaderboard:global', username);
+    const rank = await redis.zRevRank('leaderboard:global', username);
     return rank !== null ? rank + 1 : null; // Convert 0-based to 1-based
   } catch (error) {
     console.error('Error getting user rank:', error);
@@ -341,12 +341,12 @@ export async function getGameStatistics(): Promise<{
   topScore: number;
 }> {
   try {
-    const totalPlayers = await redis.zcard('leaderboard:global') || 0;
+    const totalPlayers = await redis.zCard('leaderboard:global') || 0;
     const totalGamesKey = 'stats:total_games';
     const totalGames = parseInt(await redis.get(totalGamesKey) || '0');
 
     // Get top score
-    const topScores = await redis.zrange('leaderboard:global', 0, 0, {
+    const topScores = await redis.zRange('leaderboard:global', 0, 0, {
       reverse: true,
       withScores: true
     });

--- a/test/highscoreEndpoint.test.ts
+++ b/test/highscoreEndpoint.test.ts
@@ -34,12 +34,12 @@ vi.mock('@devvit/web/server', () => {
       stringStore.set(key, next.toString());
       return next;
     },
-    async zadd(key: string, entry: { score: number; member: string }): Promise<number> {
+    async zAdd(key: string, entry: { score: number; member: string }): Promise<number> {
       const set = ensureSortedSet(key);
       set.set(entry.member, entry.score);
       return 1;
     },
-    async zrange(
+    async zRange(
       key: string,
       start: number,
       stop: number,
@@ -69,23 +69,20 @@ vi.mock('@devvit/web/server', () => {
       expiryStore.set(key, seconds);
       return 1;
     },
-    async zcard(key: string): Promise<number> {
+    async zCard(key: string): Promise<number> {
       return sortedSets.get(key)?.size ?? 0;
     },
-    async zrevrank(key: string, member: string): Promise<number | null> {
+    async zRevRank(key: string, member: string): Promise<number | null> {
       const entries = getSortedEntries(key).sort((a, b) => b[1] - a[1]);
       const index = entries.findIndex(([name]) => name === member);
       return index === -1 ? null : index;
     },
-    async hset(key: string, values: Record<string, string>): Promise<number> {
+    async hSet(key: string, values: Record<string, string>): Promise<number> {
       const current = hashStore.get(key) ?? {};
       hashStore.set(key, { ...current, ...values });
       return 1;
     },
-    async hSet(key: string, values: Record<string, string>): Promise<number> {
-      return redis.hset(key, values);
-    },
-    async hgetall(key: string): Promise<Record<string, string>> {
+    async hGetAll(key: string): Promise<Record<string, string>> {
       const current = hashStore.get(key);
       return current ? { ...current } : {};
     },


### PR DESCRIPTION
## Summary
- update dummy leaderboard seeding to call the camelCase Redis sorted set and hash helpers
- align high score API reads and writes with the camelCase Redis client surface
- expose camelCase sorted set and hash helpers in the Vitest Redis mock to mirror production usage

## Testing
- npm run build:server
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68ca63538abc832790fa0d98ff48e185