### PR TITLE
Disable SSR minification to preserve Redis method names

### DIFF
--- a/src/server/vite.config.ts
+++ b/src/server/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     ssr: 'index.ts',
     outDir: '../../dist/server',
     target: 'node22',
+    minify: false,
+    esbuild: {
+      keepNames: true,
+    },
     sourcemap: true,
     rollupOptions: {
       external: [...builtinModules],


### PR DESCRIPTION
## Summary
- disable SSR minification and preserve symbol names in the server Vite config to avoid Redis API mangling

## Testing
- npm run build:server

------
https://chatgpt.com/codex/tasks/task_b_68ca68e8ba7c832799604cf228aa1727