### PR TITLE
Fix redis game counter increment

### DIFF
--- a/src/server/api/highscores.ts
+++ b/src/server/api/highscores.ts
@@ -378,7 +378,7 @@ export async function getGameStatistics(): Promise<{
  */
 export async function incrementGamesPlayed(): Promise<void> {
   try {
-    await redis.incr('stats:total_games');
+    await redis.incrBy('stats:total_games', 1);
   } catch (error) {
     console.error('Error incrementing games played:', error);
   }


### PR DESCRIPTION
## Summary
- replace the unsupported redis.incr call with redis.incrBy for the total games counter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca8a9c107c8327a1d800176c76ae69