### PR TITLE
Refactor leaderboard data pipeline

### DIFF
--- a/src/client/services/LeaderboardService.ts
+++ b/src/client/services/LeaderboardService.ts
@@ -1,0 +1,137 @@
+import type { LeaderboardEntry, LeaderboardPeriod, LeaderboardResponse } from '../../shared/types/leaderboard';
+
+export type LeaderboardViewPeriod = Extract<LeaderboardPeriod, 'daily' | 'weekly' | 'global'>;
+
+export interface LeaderboardViewEntry extends LeaderboardEntry {
+  isCurrentUser: boolean;
+}
+
+type LeaderboardPayload = Partial<LeaderboardEntry> & {
+  score?: number | string | null;
+  rank?: number | string | null;
+  username?: string | null;
+  timestamp?: number | string | null;
+};
+
+const FALLBACK_USERNAME_PREFIX = 'player';
+
+function coerceNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+}
+
+function coerceOptionalNumber(value: unknown): number | undefined {
+  const coerced = coerceNumber(value, Number.NaN);
+  return Number.isFinite(coerced) ? coerced : undefined;
+}
+
+function sanitizeUsername(value: unknown, index: number): string {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return `${FALLBACK_USERNAME_PREFIX}_${index + 1}`;
+}
+
+function sanitizePostId(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return undefined;
+}
+
+export function normalizeLeaderboardPayload(
+  entries: Array<LeaderboardPayload | null | undefined>,
+  currentUsername: string,
+): LeaderboardViewEntry[] {
+  const deduped = new Map<string, LeaderboardViewEntry>();
+
+  entries.forEach((raw, index) => {
+    if (!raw) {
+      return;
+    }
+
+    const username = sanitizeUsername(raw.username, index);
+    const score = coerceNumber(raw.score, 0);
+    const timestamp = coerceOptionalNumber(raw.timestamp) ?? Date.now();
+    const postId = sanitizePostId(raw.postId);
+
+    const existing = deduped.get(username);
+    if (!existing || score > existing.score) {
+      const provisionalRank = coerceNumber(raw.rank, index + 1);
+
+      deduped.set(username, {
+        rank: provisionalRank > 0 ? Math.floor(provisionalRank) : index + 1,
+        username,
+        score,
+        timestamp,
+        postId,
+        isCurrentUser: username === currentUsername,
+      });
+    }
+  });
+
+  const normalized = Array.from(deduped.values());
+  normalized.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+
+    return a.username.localeCompare(b.username);
+  });
+
+  normalized.forEach((entry, index) => {
+    entry.rank = index + 1;
+    entry.isCurrentUser = entry.username === currentUsername;
+  });
+
+  return normalized;
+}
+
+class LeaderboardService {
+  private cache = new Map<LeaderboardViewPeriod, LeaderboardViewEntry[]>();
+
+  getCached(period: LeaderboardViewPeriod): LeaderboardViewEntry[] | null {
+    return this.cache.get(period) ?? null;
+  }
+
+  async fetchLeaderboard(
+    period: LeaderboardViewPeriod,
+    limit: number,
+    currentUsername: string,
+  ): Promise<LeaderboardViewEntry[]> {
+    const cached = this.cache.get(period);
+    if (cached && cached.length > 0) {
+      return cached.map(entry => ({ ...entry, isCurrentUser: entry.username === currentUsername }));
+    }
+
+    const response = await fetch(`/api/leaderboard?type=${period}&limit=${limit}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch leaderboard (${response.status})`);
+    }
+
+    const data = (await response.json()) as Partial<LeaderboardResponse> | null;
+    const normalized = normalizeLeaderboardPayload(
+      Array.isArray(data?.leaderboard) ? data?.leaderboard : [],
+      currentUsername,
+    );
+
+    this.cache.set(period, normalized);
+    return normalized;
+  }
+
+  primeCache(period: LeaderboardViewPeriod, entries: LeaderboardViewEntry[]): void {
+    this.cache.set(period, entries);
+  }
+}
+
+export const leaderboardService = new LeaderboardService();

--- a/src/server/api/highscores.ts
+++ b/src/server/api/highscores.ts
@@ -3,15 +3,13 @@
  */
 import { redis, context } from '@devvit/web/server';
 
+import type { LeaderboardEntry } from '../../shared/types/leaderboard';
+
 export interface HighScoreEntry {
   username: string;
   score: number;
   timestamp: number;
   postId?: string;
-}
-
-export interface LeaderboardEntry extends HighScoreEntry {
-  rank: number;
 }
 
 /**

--- a/src/server/utils/leaderboard.ts
+++ b/src/server/utils/leaderboard.ts
@@ -1,0 +1,97 @@
+import type { LeaderboardEntry } from '../../shared/types/leaderboard';
+
+type LeaderboardEntryInput = Partial<LeaderboardEntry> & {
+  score?: number | string | null;
+  rank?: number | string | null;
+  username?: string | null;
+  timestamp?: number | string | null;
+};
+
+const FALLBACK_USERNAME_PREFIX = 'player';
+
+function coerceNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+}
+
+function coerceOptionalNumber(value: unknown): number | undefined {
+  const coerced = coerceNumber(value, Number.NaN);
+  return Number.isFinite(coerced) ? coerced : undefined;
+}
+
+function sanitizeUsername(value: unknown, index: number): string {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return `${FALLBACK_USERNAME_PREFIX}_${index + 1}`;
+}
+
+function sanitizePostId(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  return undefined;
+}
+
+/**
+ * Normalize raw leaderboard entries returned from Redis/Devvit APIs into a safe, predictable shape.
+ *
+ * The Devvit leaderboard best practices recommend:
+ * - Always sending numeric scores in descending order.
+ * - Guaranteeing ranks are sequential and 1-based.
+ * - Ensuring usernames are present to avoid client-side rendering issues.
+ */
+export function normalizeLeaderboardEntries(
+  entries: Array<LeaderboardEntryInput | null | undefined>,
+): LeaderboardEntry[] {
+  const deduped = new Map<string, LeaderboardEntry>();
+
+  entries.forEach((raw, index) => {
+    if (!raw) {
+      return;
+    }
+
+    const username = sanitizeUsername(raw.username, index);
+    const score = coerceNumber(raw.score, 0);
+    const timestamp = coerceOptionalNumber(raw.timestamp) ?? Date.now();
+    const postId = sanitizePostId(raw.postId);
+
+    const existing = deduped.get(username);
+    if (!existing || score > existing.score) {
+      const provisionalRank = coerceNumber(raw.rank, index + 1);
+
+      deduped.set(username, {
+        rank: provisionalRank > 0 ? Math.floor(provisionalRank) : index + 1,
+        username,
+        score,
+        timestamp,
+        postId,
+      });
+    }
+  });
+
+  const normalized = Array.from(deduped.values());
+  normalized.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+
+    return a.username.localeCompare(b.username);
+  });
+
+  normalized.forEach((entry, index) => {
+    entry.rank = index + 1;
+  });
+
+  return normalized;
+}

--- a/src/shared/types/leaderboard.ts
+++ b/src/shared/types/leaderboard.ts
@@ -1,0 +1,14 @@
+export type LeaderboardPeriod = 'daily' | 'weekly' | 'global' | 'subreddit';
+
+export interface LeaderboardEntry {
+  rank: number;
+  username: string;
+  score: number;
+  timestamp?: number;
+  postId?: string;
+}
+
+export interface LeaderboardResponse {
+  leaderboard: LeaderboardEntry[];
+  type: LeaderboardPeriod;
+}

--- a/test/leaderboardService.test.ts
+++ b/test/leaderboardService.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import {
+  leaderboardService,
+  normalizeLeaderboardPayload,
+  type LeaderboardViewEntry,
+} from '../src/client/services/LeaderboardService';
+
+const now = Date.now();
+
+describe('normalizeLeaderboardPayload', () => {
+
+  it('coerces invalid scores and usernames to safe defaults', () => {
+    const result = normalizeLeaderboardPayload(
+      [
+        {
+          rank: null,
+          username: '',
+          score: null,
+          timestamp: 'not-a-number',
+        },
+        undefined,
+        {
+          rank: '3',
+          username: '  validUser  ',
+          score: '4200',
+          timestamp: now.toString(),
+        },
+      ],
+      'validUser',
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      rank: 1,
+      username: 'validUser',
+      score: 4200,
+      isCurrentUser: true,
+    });
+
+    expect(result[1].username.startsWith('player_')).toBe(true);
+    expect(result[1].score).toBe(0);
+    expect(result[1].rank).toBe(2);
+  });
+
+  it('deduplicates usernames keeping the highest score', () => {
+    const result = normalizeLeaderboardPayload(
+      [
+        { rank: 1, username: 'userA', score: 1000 },
+        { rank: 2, username: 'userA', score: 2000 },
+        { rank: 3, username: 'userB', score: 500 },
+      ],
+      'userB',
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ username: 'userA', score: 2000, rank: 1 });
+    expect(result[1]).toMatchObject({ username: 'userB', score: 500, rank: 2, isCurrentUser: true });
+  });
+});
+
+describe('leaderboardService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    leaderboardService.primeCache('daily', []);
+    leaderboardService.primeCache('weekly', []);
+    leaderboardService.primeCache('global', []);
+  });
+
+  it('returns cached entries without calling fetch', async () => {
+    const cachedEntry: LeaderboardViewEntry = {
+      rank: 1,
+      username: 'cachedPlayer',
+      score: 1234,
+      isCurrentUser: false,
+      timestamp: now,
+    };
+
+    leaderboardService.primeCache('daily', [cachedEntry]);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const result = await leaderboardService.fetchLeaderboard('daily', 10, 'anotherPlayer');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      username: 'cachedPlayer',
+      rank: 1,
+      score: 1234,
+      isCurrentUser: false,
+    });
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/test/uiComponent.test.ts
+++ b/test/uiComponent.test.ts
@@ -114,6 +114,14 @@ vi.mock('../src/client/services/HighScoreService', () => ({
   },
 }));
 
+vi.mock('../src/client/services/LeaderboardService', () => ({
+  leaderboardService: {
+    fetchLeaderboard: vi.fn(async () => []),
+    getCached: vi.fn(() => null),
+    primeCache: vi.fn(),
+  },
+}));
+
 import * as Phaser from 'phaser';
 import { DS } from '../src/client/game/config/DesignSystem';
 import { UIComponent } from '../src/client/game/presentation/ui/components/UIComponent';


### PR DESCRIPTION
## Summary
- introduce shared leaderboard types, server normalization utilities, and a client-side leaderboard service for consistent data handling
- refactor ModernLeaderboardUI to rely on the new service, support the global period naming, and guard against missing score values
- add unit coverage for the leaderboard service and adjust UI tests for the new dependency

## Testing
- npm run type-check *(fails: existing strictness violations in hex coordinate utilities and renderer code)*
- npm test *(fails: pre-existing responsive layout expectations)*
- dotnet test *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca8c65d47c8327ba68cf0bc9832e62