### PR TITLE
Align board preview hex rotation with pieces

### DIFF
--- a/src/client/game/presentation/board/BoardRenderer.ts
+++ b/src/client/game/presentation/board/BoardRenderer.ts
@@ -56,7 +56,8 @@ export class BoardRenderer {
     this.themeProvider = new NeonThemeProvider();
     this.viewport = viewport;
     this.hexRenderer = new HexagonRenderer(this.themeProvider);
-    // No rotation needed - renderer already defaults to pointy-top
+    // Match the 30° runtime rotation used by board textures and piece images
+    this.hexRenderer.setRotationOffset(Math.PI / 6);
 
     this.cellBaseImages = new Map();
     this.cellFillImages = new Map();


### PR DESCRIPTION
## Summary
- rotate hexagon renderer output by 30 degrees to match board textures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cac59db5a88327b12f32928992596c