### PR TITLE
Align board cell rotation with pieces

### DIFF
--- a/src/client/game/presentation/board/BoardRenderer.ts
+++ b/src/client/game/presentation/board/BoardRenderer.ts
@@ -169,10 +169,10 @@ export class BoardRenderer {
     const dim = radius * 2;
     const base = this.scene.add.image(position.x, position.y, RenderConfig.TEXTURE_KEYS.HEX_BASE_SVG).setOrigin(0.5);
     base.setDisplaySize(dim, dim);
-    // No rotation - images should already be in correct orientation
+    base.setRotation(Math.PI / 6);  // Ensure consistent 30° rotation at creation time
     const fill = this.scene.add.image(position.x, position.y, RenderConfig.TEXTURE_KEYS.HEX_FILL_SVG).setOrigin(0.5);
     fill.setDisplaySize(dim - 2, dim - 2);
-    // No rotation - images should already be in correct orientation
+    fill.setRotation(Math.PI / 6);  // Ensure consistent 30° rotation at creation time
     fill.setVisible(false);
 
     // Create interactive zone


### PR DESCRIPTION
## Summary
- rotate board cell base and fill sprites by 30° when created to match piece orientation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cacf38f4448327a0b3ee5d79d55a21