### PR TITLE
Ensure share rescue overlay coexists with game over panel

### DIFF
--- a/src/client/game/scenes/MainScene.ts
+++ b/src/client/game/scenes/MainScene.ts
@@ -572,11 +572,10 @@ export class MainScene extends Phaser.Scene {
 
     // Only update score - it will automatically handle highScore in the store
     store.setScore(this.score);
+    store.setShareRescueOffer(null);
+    store.setGameState('gameOver');
 
-    const offeredRescue = await this.maybeOfferShareRescue();
-    if (!offeredRescue) {
-      store.setGameState('gameOver');
-    }
+    await this.maybeOfferShareRescue();
   }
 
   private captureGameScreenshot(): string | null {
@@ -654,7 +653,6 @@ export class MainScene extends Phaser.Scene {
         username,
       });
       shareService.markPromptShown(username);
-      window.gameStore?.getState().setGameState('sharePrompt');
       return true;
     } catch (error) {
       console.error('Failed to evaluate share rescue eligibility:', error);
@@ -709,7 +707,7 @@ export class MainScene extends Phaser.Scene {
       });
 
       store.setShowNoSpaceToast(false);
-      store.setGameState('sharePrompt');
+      store.setGameState('gameOver');
     } catch (error) {
       console.error('Failed to trigger share rescue test:', error);
     }

--- a/src/client/ui/App.tsx
+++ b/src/client/ui/App.tsx
@@ -69,7 +69,7 @@ export const App: React.FC = () => {
       )}
 
       {/* Share to Continue Panel - offered once per day */}
-      {gameState === 'sharePrompt' && shareRescueOffer && (
+      {shareRescueOffer && (
         <ShareRescuePanel />
       )}
 


### PR DESCRIPTION
## Summary
- ensure the Phaser scene records the game over state before checking the share rescue offer and clears stale offers
- stop using the sharePrompt game state when offering a rescue and rely on the dedicated store flag instead
- render the ShareRescuePanel whenever an offer exists so it can stack on top of the game-over panel

## Testing
- `npm run test` *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cfb5f5c0ac8327bac4ecac9160bc6d