### PR TITLE
Ensure game over panel shows despite share rescue delays

### DIFF
--- a/src/client/game/scenes/MainScene.ts
+++ b/src/client/game/scenes/MainScene.ts
@@ -568,14 +568,24 @@ export class MainScene extends Phaser.Scene {
   private async resolveGameOverFlow(): Promise<void> {
     const storeApi = window.gameStore;
     if (!storeApi) {
+      logger.error('[GameOverFlow] Game store API unavailable during game over resolution');
       return;
     }
 
-    await resolveGameOverFlowWithStore({
-      score: this.score,
-      storeApi,
-      offerShareRescue: () => this.maybeOfferShareRescue(),
-    });
+    try {
+      await resolveGameOverFlowWithStore({
+        score: this.score,
+        storeApi,
+        offerShareRescue: () => this.maybeOfferShareRescue(),
+      });
+    } catch (error) {
+      logger.error('[GameOverFlow] Unhandled error resolving game over flow:', error);
+      try {
+        storeApi.getState().setGameState('gameOver');
+      } catch (fallbackError) {
+        logger.error('[GameOverFlow] Failed to force game over state after error:', fallbackError);
+      }
+    }
   }
 
   private captureGameScreenshot(): string | null {


### PR DESCRIPTION
## Summary
- ensure the game immediately enters the game over state before evaluating share rescue offers and add defensive logging to the flow
- harden the Phaser scene's game over resolver with additional logging and a fallback state update when unexpected errors occur
- extend resolveGameOverFlow unit tests to cover the new transition order and error logging behaviour

## Testing
- npm test -- resolveGameOverFlow

------
https://chatgpt.com/codex/tasks/task_b_68cfc0a00abc83279291fdb412864de6