### PR TITLE
Ensure game over panel appears after high score updates

### DIFF
--- a/test/resolveGameOverFlow.test.ts
+++ b/test/resolveGameOverFlow.test.ts
@@ -121,4 +121,25 @@ describe('resolveGameOverFlowWithStore', () => {
 
     loggerSpy.mockRestore();
   });
+
+  it('logs score sync failures but still transitions to game over', async () => {
+    const mocks = createStoreMocks(4_000);
+    const error = new Error('setScore failed');
+    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    mocks.setScore.mockImplementation(() => {
+      throw error;
+    });
+
+    await resolveGameOverFlowWithStore({
+      score: 4_500,
+      storeApi: mocks.storeApi,
+      offerShareRescue: async () => false,
+    });
+
+    expect(mocks.setGameState).toHaveBeenCalledWith('gameOver');
+    expect(loggerSpy).toHaveBeenCalledWith('[GameOverFlow] Failed to sync score during game over flow:', error);
+
+    loggerSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- guard each game store interaction in the game over flow so the UI still reaches the game over state when score syncing fails
- add detailed console logging for store access, score sync, and state transitions during the game over flow
- cover the failure scenario with a regression test for resolveGameOverFlowWithStore

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cfc7f03570832798becac55299c069